### PR TITLE
S5: implement edge creation, deletion, and reactive skill map updates

### DIFF
--- a/app/api/skillApi.ts
+++ b/app/api/skillApi.ts
@@ -1,5 +1,5 @@
 import { ApiService } from "./apiService";
-import { Skill } from "@/types/skill";
+import { Skill, Dependency } from "@/types/skill";
 
 export function createSkill(
   api: ApiService,
@@ -19,4 +19,17 @@ export function updateSkill(
 
 export function deleteSkill(api: ApiService, skillId: number): Promise<void> {
   return api.delete<void>(`/skills/${skillId}`);
+}
+
+export function createDependency(
+  api: ApiService,
+  skillMapId: number,
+  fromSkillId: number,
+  toSkillId: number,
+): Promise<Dependency> {
+  return api.post<Dependency>(`/skillmaps/${skillMapId}/dependencies`, { fromSkillId, toSkillId });
+}
+
+export function deleteDependency(api: ApiService, dependencyId: number): Promise<void> {
+  return api.delete<void>(`/dependencies/${dependencyId}`);
 }

--- a/app/api/skillApi.ts
+++ b/app/api/skillApi.ts
@@ -12,7 +12,7 @@ export function createSkill(
 export function updateSkill(
   api: ApiService,
   skillId: number,
-  data: { name?: string; description?: string; difficulty?: string; resources?: string },
+  data: { name?: string; description?: string; difficulty?: string; resources?: string; positionX?: number; level?: number },
 ): Promise<Skill> {
   return api.patch<Skill>(`/skills/${skillId}`, data);
 }

--- a/app/skillmaps/[id]/components/GradientEdge.tsx
+++ b/app/skillmaps/[id]/components/GradientEdge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { EdgeProps, getSmoothStepPath, useNodes } from "@xyflow/react";
 
 const colorMap: Record<string, string> = {
@@ -11,6 +11,7 @@ const colorMap: Record<string, string> = {
 };
 
 const GradientEdge: React.FC<EdgeProps> = ({ id, sourceX, sourceY, targetX, targetY, source, target }) => {
+  const [hovered, setHovered] = useState(false);
   const nodes = useNodes();
   const sourceNode = nodes.find((n) => n.id === source);
   const targetNode = nodes.find((n) => n.id === target);
@@ -26,15 +27,22 @@ const GradientEdge: React.FC<EdgeProps> = ({ id, sourceX, sourceY, targetX, targ
   const [edgePath] = getSmoothStepPath({ sourceX, sourceY, targetX, targetY, borderRadius: 0 });
 
   return (
-    <>
+    <g onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
       <defs>
         <linearGradient id={gradientId} x1={sourceX} y1={sourceY} x2={targetX} y2={targetY} gradientUnits="userSpaceOnUse">
           <stop offset="0%" stopColor={sourceColor} />
           <stop offset="100%" stopColor={targetColor} />
         </linearGradient>
       </defs>
-      <path d={edgePath} stroke={`url(#${gradientId})`} strokeWidth={1.5} fill="none" />
-    </>
+      <path d={edgePath} stroke="transparent" strokeWidth={16} fill="none" />
+      <path
+        d={edgePath}
+        stroke={`url(#${gradientId})`}
+        strokeWidth={hovered ? 2.5 : 1.5}
+        fill="none"
+        style={{ filter: hovered ? `drop-shadow(0 0 5px ${sourceColor})` : undefined, transition: "stroke-width 0.15s" }}
+      />
+    </g>
   );
 };
 

--- a/app/skillmaps/[id]/components/SkillNode.tsx
+++ b/app/skillmaps/[id]/components/SkillNode.tsx
@@ -16,13 +16,13 @@ const SkillNode: React.FC<NodeProps> = ({ data }) => {
 
   return (
     <div className={clsx(styles["skill-node"], styles[`status-${status}`])}>
-      <Handle type="target" position={Position.Top} className={styles["skill-node-handle"]} />
+      <Handle type="source" position={Position.Top} className={styles["skill-node-handle"]} />
       <span className={styles["skill-node__dot"]} />
       <span className={styles["skill-node__label"]}>{label}</span>
       {progress !== undefined && (
         <span className={styles["skill-node__progress"]}>{progress}%</span>
       )}
-      <Handle type="source" position={Position.Bottom} className={styles["skill-node-handle"]} />
+      <Handle type="target" position={Position.Bottom} className={styles["skill-node-handle"]} />
     </div>
   );
 };

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -68,6 +68,12 @@ const SkillMapEditorPage: React.FC = () => {
         setSkillMap(map);
         setSkills(graph.skills);
 
+        const difficultyStatus: Record<string, string> = {
+          easy: "done",
+          medium: "active",
+          hard: "secondary",
+        };
+
         const skillNodes: Node[] = graph.skills.map((skill) => ({
           id: String(skill.id),
           type: "skill",
@@ -77,7 +83,7 @@ const SkillMapEditorPage: React.FC = () => {
           },
           data: {
             label: skill.name,
-            status: skill.isUnlocked ? "active" : "default",
+            status: difficultyStatus[skill.difficulty] ?? "default",
           },
         }));
 
@@ -188,13 +194,16 @@ const SkillMapEditorPage: React.FC = () => {
       const fromSkillId = Number(connection.source);
       const toSkillId = Number(connection.target);
       const newEdge: Edge = { ...connection, id: `e${fromSkillId}-${toSkillId}`, type: "gradient" };
+      const provisional: Dependency = { id: -1, fromSkillId, toSkillId, createdAt: "", updatedAt: "" };
       setEdges((eds) => addEdge(newEdge, eds));
+      setDependencies((deps) => [...deps, provisional]);
       try {
         const dep = await createDependency(api, id, fromSkillId, toSkillId);
-        setDependencies((deps) => [...deps, dep]);
+        setDependencies((deps) => deps.map((d) => (d === provisional ? dep : d)));
       } catch (err) {
         toast.error(`Dependency error: ${(err as Error).message}`);
         setEdges((eds) => eds.filter((e) => e.id !== newEdge.id));
+        setDependencies((deps) => deps.filter((d) => d !== provisional));
       }
     },
     [api, id]
@@ -206,10 +215,11 @@ const SkillMapEditorPage: React.FC = () => {
         (d) => d.fromSkillId === Number(edge.source) && d.toSkillId === Number(edge.target)
       );
       if (!dep) return;
+      if (dep.id < 0) { toast("Connection is still being saved…"); return; }
 
       toast((t) => (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <span>Delete this connection?</span>
+          <span>Delete this dependency?</span>
           <div style={{ display: "flex", gap: 8 }}>
             <button
               className="btn-gradient"
@@ -233,7 +243,14 @@ const SkillMapEditorPage: React.FC = () => {
             </button>
           </div>
         </div>
-      ), { duration: Infinity });
+      ), {
+        duration: Infinity,
+        style: {
+          background: "var(--bg-elevated)",
+          color: "var(--text-bright)",
+          border: "1px solid var(--border-color)",
+        },
+      });
     },
     [api, dependencies]
   );

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -8,13 +8,15 @@ import { BookOpen, Globe, Pencil, Plus } from "lucide-react";
 import { useApi } from "@/hooks/useApi";
 import { getMe } from "@/api/userApi";
 import { getSkillMap, getSkillMapGraph, getSkillMapMembers, updateSkillMap } from "@/api/skillmapApi";
+import { createDependency, deleteDependency } from "@/api/skillApi";
 import { User } from "@/types/user";
-import { Skill } from "@/types/skill";
+import { Skill, Dependency } from "@/types/skill";
 import { SkillMap } from "@/types/skillmap";
 import SkillNode from "./components/SkillNode";
 import GradientEdge from "./components/GradientEdge";
 import LaneSeparators from "./components/LaneSeparators";
 import SkillModal from "./components/SkillModal";
+import toast from "react-hot-toast";
 import styles from "@/styles/skillmaps.module.css";
 
 const LANE_HEIGHT = 200;
@@ -32,6 +34,7 @@ const SkillMapEditorPage: React.FC = () => {
 
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
+  const [dependencies, setDependencies] = useState<Dependency[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
   const [skillMap, setSkillMap] = useState<SkillMap | null>(null);
   const [user, setUser] = useState<User | null>(null);
@@ -87,6 +90,7 @@ const SkillMapEditorPage: React.FC = () => {
 
         setNodes(skillNodes);
         setEdges(skillEdges);
+        setDependencies(graph.dependencies);
       } catch {
         // keep empty graph on error
       } finally {
@@ -122,10 +126,58 @@ const SkillMapEditorPage: React.FC = () => {
   };
 
   const handleConnect = useCallback(
-    (connection: Connection) => {
-      setEdges((eds) => addEdge({ ...connection, type: "gradient" }, eds));
+    async (connection: Connection) => {
+      const fromSkillId = Number(connection.source);
+      const toSkillId = Number(connection.target);
+      const newEdge: Edge = { ...connection, id: `e${fromSkillId}-${toSkillId}`, type: "gradient" };
+      setEdges((eds) => addEdge(newEdge, eds));
+      try {
+        const dep = await createDependency(api, id, fromSkillId, toSkillId);
+        setDependencies((deps) => [...deps, dep]);
+      } catch (err) {
+        toast.error(`Dependency error: ${(err as Error).message}`);
+        setEdges((eds) => eds.filter((e) => e.id !== newEdge.id));
+      }
     },
-    []
+    [api]
+  );
+
+  const handleEdgeClick = useCallback(
+    (_: React.MouseEvent, edge: Edge) => {
+      const dep = dependencies.find(
+        (d) => d.fromSkillId === Number(edge.source) && d.toSkillId === Number(edge.target)
+      );
+      if (!dep) return;
+
+      toast((t) => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <span>Delete this connection?</span>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              className="btn-gradient"
+              onClick={async () => {
+                toast.dismiss(t.id);
+                setEdges((eds) => eds.filter((e) => e.id !== edge.id));
+                setDependencies((deps) => deps.filter((d) => d.id !== dep.id));
+                try {
+                  await deleteDependency(api, dep.id);
+                } catch {
+                  setEdges((eds) => [...eds, edge]);
+                  setDependencies((deps) => [...deps, dep]);
+                  toast.error("Failed to delete connection.");
+                }
+              }}
+            >
+              Confirm
+            </button>
+            <button className="btn-ghost" onClick={() => toast.dismiss(t.id)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      ), { duration: Infinity });
+    },
+    [api, dependencies]
   );
 
 
@@ -186,6 +238,7 @@ const SkillMapEditorPage: React.FC = () => {
           edgeTypes={edgeTypes}
           onNodeClick={handleNodeClick}
           onConnect={handleConnect}
+          onEdgeClick={handleEdgeClick}
 
           fitView
           fitViewOptions={{ padding: 0.3 }}

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { ReactFlow, Background, Node, Edge } from "@xyflow/react";
+import { ReactFlow, Background, Node, Edge, addEdge, Connection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { BookOpen, Globe, Pencil, Plus } from "lucide-react";
 import { useApi } from "@/hooks/useApi";
@@ -121,6 +121,14 @@ const SkillMapEditorPage: React.FC = () => {
     setRefreshKey((k) => k + 1);
   };
 
+  const handleConnect = useCallback(
+    (connection: Connection) => {
+      setEdges((eds) => addEdge({ ...connection, type: "gradient" }, eds));
+    },
+    []
+  );
+
+
   if (loading) {
     return <div className={styles["sm-loading"]}>Loading...</div>;
   }
@@ -177,12 +185,14 @@ const SkillMapEditorPage: React.FC = () => {
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           onNodeClick={handleNodeClick}
+          onConnect={handleConnect}
+
           fitView
           fitViewOptions={{ padding: 0.3 }}
-          nodesConnectable={false}
-          panOnDrag={false}
+          panOnDrag={true}
+          panOnScroll={true}
           zoomOnScroll={false}
-          zoomOnPinch={false}
+          zoomOnPinch={true}
           zoomOnDoubleClick={false}
           proOptions={{ hideAttribution: true }}
         >

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { ReactFlow, Background, Node, Edge, addEdge, Connection, applyNodeChanges, NodeChange } from "@xyflow/react";
+import { ReactFlow, Background, Node, Edge, addEdge, Connection, applyNodeChanges, NodeChange, IsValidConnection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { BookOpen, Globe, Pencil, Plus } from "lucide-react";
 import { useApi } from "@/hooks/useApi";
@@ -172,6 +172,17 @@ const SkillMapEditorPage: React.FC = () => {
     [api, skillMap, skills]
   );
 
+  const isValidConnection: IsValidConnection = useCallback(
+    (connection) => {
+      if (connection.source === connection.target) return false;
+      const sourceSkill = skills.find((s) => String(s.id) === connection.source);
+      const targetSkill = skills.find((s) => String(s.id) === connection.target);
+      if (!sourceSkill || !targetSkill) return false;
+      return sourceSkill.level < targetSkill.level;
+    },
+    [skills]
+  );
+
   const handleConnect = useCallback(
     async (connection: Connection) => {
       const fromSkillId = Number(connection.source);
@@ -186,7 +197,7 @@ const SkillMapEditorPage: React.FC = () => {
         setEdges((eds) => eds.filter((e) => e.id !== newEdge.id));
       }
     },
-    [api]
+    [api, id]
   );
 
   const handleEdgeClick = useCallback(
@@ -287,6 +298,7 @@ const SkillMapEditorPage: React.FC = () => {
           onNodeClick={handleNodeClick}
           onNodeDragStop={handleNodeDragStop}
           onConnect={handleConnect}
+          isValidConnection={isValidConnection}
           onEdgeClick={handleEdgeClick}
 
           fitView

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -2,13 +2,13 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { ReactFlow, Background, Node, Edge, addEdge, Connection } from "@xyflow/react";
+import { ReactFlow, Background, Node, Edge, addEdge, Connection, applyNodeChanges, NodeChange } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { BookOpen, Globe, Pencil, Plus } from "lucide-react";
 import { useApi } from "@/hooks/useApi";
 import { getMe } from "@/api/userApi";
 import { getSkillMap, getSkillMapGraph, getSkillMapMembers, updateSkillMap } from "@/api/skillmapApi";
-import { createDependency, deleteDependency } from "@/api/skillApi";
+import { createDependency, deleteDependency, updateSkill } from "@/api/skillApi";
 import { User } from "@/types/user";
 import { Skill, Dependency } from "@/types/skill";
 import { SkillMap } from "@/types/skillmap";
@@ -125,6 +125,53 @@ const SkillMapEditorPage: React.FC = () => {
     setRefreshKey((k) => k + 1);
   };
 
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setNodes((nds) => applyNodeChanges(changes, nds)),
+    []
+  );
+
+  const handleNodeDragStop = useCallback(
+    async (_: React.MouseEvent, node: Node) => {
+      const numLevels = skillMap?.numberOfLevels ?? 1;
+      const rawLevel = numLevels - (node.position.y - SKILL_Y_OFFSET) / LANE_HEIGHT;
+      const newLevel = Math.max(1, Math.min(numLevels, Math.round(rawLevel)));
+      const snappedY = (numLevels - newLevel) * LANE_HEIGHT + SKILL_Y_OFFSET;
+      const newPositionX = Math.round(node.position.x);
+
+      const originalSkill = skills.find((s) => s.id === Number(node.id));
+      if (!originalSkill) return;
+      if (originalSkill.positionX === newPositionX && originalSkill.level === newLevel) return;
+
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === node.id ? { ...n, position: { x: newPositionX, y: snappedY } } : n
+        )
+      );
+      setSkills((prev) =>
+        prev.map((s) =>
+          s.id === Number(node.id) ? { ...s, positionX: newPositionX, level: newLevel } : s
+        )
+      );
+
+      try {
+        await updateSkill(api, Number(node.id), { positionX: newPositionX, level: newLevel });
+      } catch {
+        setNodes((nds) =>
+          nds.map((n) =>
+            n.id === node.id
+              ? { ...n, position: { x: originalSkill.positionX, y: (numLevels - originalSkill.level) * LANE_HEIGHT + SKILL_Y_OFFSET } }
+              : n
+          )
+        );
+        setSkills((prev) =>
+          prev.map((s) => (s.id === Number(node.id) ? originalSkill : s))
+        );
+        toast.error("Failed to move skill.");
+      }
+    },
+    [api, skillMap, skills]
+  );
+
   const handleConnect = useCallback(
     async (connection: Connection) => {
       const fromSkillId = Number(connection.source);
@@ -236,7 +283,9 @@ const SkillMapEditorPage: React.FC = () => {
           edges={edges}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
+          onNodesChange={onNodesChange}
           onNodeClick={handleNodeClick}
+          onNodeDragStop={handleNodeDragStop}
           onConnect={handleConnect}
           onEdgeClick={handleEdgeClick}
 

--- a/app/styles/skill-node.module.css
+++ b/app/styles/skill-node.module.css
@@ -39,6 +39,11 @@
 
 .skill-node-handle {
   opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.skill-node:hover .skill-node-handle {
+  opacity: 1;
 }
 
 .skill-node__dot {


### PR DESCRIPTION
- dragging from a node handle to create a dependency (hovering over node lets two small points appear, clicking on a point and dragging to node to connect allows to create dependency)
- edges are validated upward-only (lower level -> higher level)
- hovering over a dependency illuminates the selected dependency, clicking on it allows you to delete it via a confirmation toast
- skill nodes are coloured by difficulty (which can be changed; easy = green, medium = purple, hard = pink)
- nodes can be moved within their level, the dependencies adapt automatically
- fixed a backend bug: incomplete TODO within GET / skillmaps/{id}/graph caused return of empty dependency list