### PR TITLE
feat(S18/S19): implement skill map import and export

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -136,6 +136,17 @@ export class ApiService {
     );
   }
 
+  public async postFormData<T>(endpoint: string, data: FormData): Promise<T> {
+    const url = `${this.baseURL}${endpoint}`;
+    const { "Content-Type": _, ...headersWithoutContentType } = this.defaultHeaders as Record<string, string>;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: headersWithoutContentType,
+      body: data,
+    });
+    return this.processResponse<T>(res, "An error occurred while uploading the data.\n");
+  }
+
   public async download(endpoint: string): Promise<Blob> {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, { method: "GET", headers: this.defaultHeaders, cache: "no-store" });

--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -136,6 +136,24 @@ export class ApiService {
     );
   }
 
+  public async download(endpoint: string): Promise<Blob> {
+    const url = `${this.baseURL}${endpoint}`;
+    const res = await fetch(url, { method: "GET", headers: this.defaultHeaders, cache: "no-store" });
+    if (!res.ok) {
+      let errorDetail = res.statusText;
+      try {
+        const errorInfo = await res.json();
+        if (errorInfo?.message) errorDetail = errorInfo.message;
+      } catch { /* keep statusText */ }
+      const error: ApplicationError = new Error(`Download failed (${res.status}: ${errorDetail})`) as ApplicationError;
+      error.info = JSON.stringify({ status: res.status, statusText: res.statusText }, null, 2);
+      error.status = res.status;
+      error.details = errorDetail;
+      throw error;
+    }
+    return res.blob();
+  }
+
   /**
    * DELETE request.
    * @param endpoint - The API endpoint (e.g. "/users/123").

--- a/app/api/skillmapApi.ts
+++ b/app/api/skillmapApi.ts
@@ -44,3 +44,9 @@ export function deleteSkillMap(api: ApiService, id: number): Promise<void> {
 export function exportSkillMap(api: ApiService, id: number): Promise<Blob> {
   return api.download(`/skillmaps/${id}/export`);
 }
+
+export function importSkillMap(api: ApiService, file: File): Promise<SkillMap> {
+  const form = new FormData();
+  form.append("file", file);
+  return api.postFormData<SkillMap>("/skillmaps/import", form);
+}

--- a/app/api/skillmapApi.ts
+++ b/app/api/skillmapApi.ts
@@ -40,3 +40,7 @@ export function getSkillMapMembers(api: ApiService, id: number): Promise<SkillMa
 export function deleteSkillMap(api: ApiService, id: number): Promise<void> {
   return api.delete<void>(`/skillmaps/${id}`);
 }
+
+export function exportSkillMap(api: ApiService, id: number): Promise<Blob> {
+  return api.download(`/skillmaps/${id}/export`);
+}

--- a/app/skillmaps/[id]/components/ExportModal.tsx
+++ b/app/skillmaps/[id]/components/ExportModal.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, { useState } from "react";
+import { FileJson, Italic } from "lucide-react";
+import styles from "@/styles/skillmaps.module.css";
+
+type ExportModalProps = {
+  open: boolean;
+  mapTitle: string;
+  onExport: () => Promise<void>;
+  onClose: () => void;
+};
+
+const ExportModal: React.FC<ExportModalProps> = ({ open, mapTitle, onExport, onClose }) => {
+  const [exporting, setExporting] = useState(false);
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    setExporting(true);
+    try {
+      await onExport();
+      onClose();
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div className={styles["modal-backdrop"]} onClick={onClose}>
+      <div className={styles["modal"]} onClick={(e) => e.stopPropagation()}>
+        <h2 className={styles["export-modal-title"]}>Export Skill Map</h2>
+        {/*<p className={styles["export-modal-subtitle"]}>Export skill map: {mapTitle}</p>*/}
+
+        <div className={styles["export-format-grid"]}>
+          <div className={`${styles["export-format-card"]} ${styles["export-format-card--selected"]}`}>
+            <FileJson size={28} />
+            <span>JSON</span>
+          </div>
+        </div>
+
+        <div className={styles["export-actions"]}>
+          <button type="button" className="btn-ghost" onClick={onClose} disabled={exporting}>
+            Cancel
+          </button>
+          <button type="button" className="btn-gradient" onClick={handleConfirm} disabled={exporting}>
+            {exporting ? "Exporting…" : "Export"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExportModal;

--- a/app/skillmaps/[id]/edit/page.tsx
+++ b/app/skillmaps/[id]/edit/page.tsx
@@ -165,7 +165,7 @@ const EditSkillMapPage: React.FC = () => {
             </div>
             <button type="submit" className="btn-gradient btn-full">Save</button>
             <button type="button" className="btn-ghost btn-full" onClick={() => router.push(`/skillmaps/${id}`)}>Cancel</button>
-            <div style={{ borderTop: "1px solid rgba(255,255,255,0.1)", paddingTop: "1rem", marginTop: "0.5rem" }}>
+<div style={{ borderTop: "1px solid rgba(255,255,255,0.1)", paddingTop: "1rem", marginTop: "0.5rem" }}>
               {!showDeleteConfirm ? (
                 <button
                   type="button"

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -4,13 +4,13 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ReactFlow, Background, Node, Edge, PanOnScrollMode, addEdge, Connection, applyNodeChanges, NodeChange, IsValidConnection } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Globe, Pencil, Plus, Play, Square, Copy, ChevronLeft, LogOut } from "lucide-react";
+import { Globe, Pencil, Plus, Play, Square, Copy, ChevronLeft, LogOut, Download } from "lucide-react";
 import { useApi } from "@/hooks/useApi";
 import { useDashboardPolling } from "@/hooks/useDashboardPolling";
 import { ApiContext } from "@/context/ApiContext";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import { getMe } from "@/api/userApi";
-import { getSkillMap, getSkillMapGraph, updateSkillMap } from "@/api/skillmapApi";
+import { getSkillMap, getSkillMapGraph, updateSkillMap, exportSkillMap } from "@/api/skillmapApi";
 import { createDependency, deleteDependency, getSkill, updateSkill } from "@/api/skillApi";
 import { startSession, endSession } from "@/api/sessionApi";
 import { ApplicationError } from "@/types/error";
@@ -180,6 +180,10 @@ const SkillMapEditorPage: React.FC = () => {
     clearToken();
     clearId();
     router.push("/login");
+  };
+
+  const handleExport = async () => {
+    await exportSkillMap(api, id);
   };
 
   const handleAddSkill = () => {
@@ -360,6 +364,12 @@ const SkillMapEditorPage: React.FC = () => {
             <button className={`btn-ghost ${styles["sm-nav-btn"]}`} onClick={() => router.push(`/skillmaps/${id}/edit`)}>
               <Pencil size={14} />
               Edit
+            </button>
+          )}
+          {!isActive && (
+            <button className={`btn-ghost ${styles["sm-nav-btn"]}`} onClick={handleExport}>
+              <Download size={14} />
+              Export
             </button>
           )}
           {isOwner && skillMap?.inviteCode && (

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -59,6 +59,7 @@ const LANE_HEIGHT = 200;
 const SKILL_Y_OFFSET = 70;
 const NAV_HEIGHT = 56;
 
+
 const nodeTypes = { skill: SkillNode };
 const edgeTypes = { gradient: GradientEdge };
 
@@ -233,7 +234,7 @@ const SkillMapEditorPage: React.FC = () => {
 
       try {
         await updateSkill(api, Number(node.id), { positionX: newPositionX, level: newLevel });
-      } catch {
+      } catch (err) {
         setNodes((nds) =>
           nds.map((n) =>
             n.id === node.id
@@ -244,7 +245,9 @@ const SkillMapEditorPage: React.FC = () => {
         setSkills((prev) =>
           prev.map((s) => (s.id === Number(node.id) ? originalSkill : s))
         );
-        toast.error("Failed to move skill.");
+        const raw = (err as ApplicationError).details ?? "Failed to move skill.";
+        const msg = raw.replace(/^New level violates dependency:\s*/i, "").replace(/^Illegal level change:\s*/i, "");
+        toast.error(msg.charAt(0).toUpperCase() + msg.slice(1));
       }
     },
     [api, skillMap, skills]

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -25,6 +25,7 @@ import SkillModal from "./components/SkillModal";
 import CollabView from "./components/CollabView";
 import SkillDetailPanel from "./components/SkillDetailPanel";
 import SkillLegend from "./components/SkillLegend";
+import ExportModal from "./components/ExportModal";
 import styles from "@/styles/skillmaps.module.css";
 import collabStyles from "@/styles/collab.module.css";
 import toast from "react-hot-toast";
@@ -87,6 +88,7 @@ const SkillMapEditorPage: React.FC = () => {
   const isOwner = skillMap?.ownerId === user?.id;
   const canPublish = isOwner && !skillMap?.isPublic;
   const [modalOpen, setModalOpen] = useState(false);
+  const [exportModalOpen, setExportModalOpen] = useState(false);
   const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
   const [selectedSkillRating, setSelectedSkillRating] = useState<number | null>(null);
@@ -183,7 +185,18 @@ const SkillMapEditorPage: React.FC = () => {
   };
 
   const handleExport = async () => {
-    await exportSkillMap(api, id);
+    try {
+      const blob = await exportSkillMap(api, id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${skillMap?.title ?? "skillmap"}-export.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success("Skill map exported!");
+    } catch (err) {
+      toast.error((err as ApplicationError).details ?? "Failed to export skill map.");
+    }
   };
 
   const handleAddSkill = () => {
@@ -367,7 +380,7 @@ const SkillMapEditorPage: React.FC = () => {
             </button>
           )}
           {!isActive && (
-            <button className={`btn-ghost ${styles["sm-nav-btn"]}`} onClick={handleExport}>
+            <button className={`btn-ghost ${styles["sm-nav-btn"]}`} onClick={() => setExportModalOpen(true)}>
               <Download size={14} />
               Export
             </button>
@@ -532,6 +545,13 @@ const SkillMapEditorPage: React.FC = () => {
           )}
         </>
       )}
+
+      <ExportModal
+        open={exportModalOpen}
+        mapTitle={skillMap?.title ?? ""}
+        onExport={handleExport}
+        onClose={() => setExportModalOpen(false)}
+      />
 
       {selectedSkill && (
         <SkillDetailPanel

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
-import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, exportSkillMap } from "@/api/skillmapApi";
+import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, exportSkillMap, importSkillMap } from "@/api/skillmapApi";
 import { getMe } from "@/api/userApi";
 import { SkillMap } from "@/types/skillmap";
 import { User } from "@/types/user";
@@ -33,6 +33,11 @@ const SkillMapsPage: React.FC = () => {
   const [showJoinInput, setShowJoinInput] = useState(false);
   const [inviteCode, setInviteCode] = useState("");
   const [exportingMap, setExportingMap] = useState<SkillMap | null>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImport = async (_file: File) => {
+    await importSkillMap(api, _file);
+  };
 
   const handleExport = async (mapId: number, title: string) => {
     try {
@@ -176,6 +181,14 @@ const SkillMapsPage: React.FC = () => {
         </div>
         <div className={styles['sm-join-area']}>
           <form className={styles['sm-join-form']} onSubmit={handleJoin}>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".json"
+              style={{ display: "none" }}
+              onChange={(e) => { const f = e.target.files?.[0]; if (f) handleImport(f); e.target.value = ""; }}
+            />
+            <button type="button" className="btn-ghost" onClick={() => importInputRef.current?.click()}>Import Map</button>
             <button type="button" className="btn-ghost" onClick={() => { setShowJoinInput(!showJoinInput); setInviteCode(""); }}>{showJoinInput ? "Cancel" : "+ Join Map"}</button>
             {showJoinInput && (
               <input

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -35,8 +35,13 @@ const SkillMapsPage: React.FC = () => {
   const [exportingMap, setExportingMap] = useState<SkillMap | null>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
 
-  const handleImport = async (_file: File) => {
-    await importSkillMap(api, _file);
+  const handleImport = async (file: File) => {
+    try {
+      const map = await importSkillMap(api, file);
+      router.push(`/skillmaps/${map.id}`);
+    } catch (err) {
+      toast.error((err as ApplicationError).details ?? "Failed to import skill map.");
+    }
   };
 
   const handleExport = async (mapId: number, title: string) => {

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -3,11 +3,11 @@
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
-import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap } from "@/api/skillmapApi";
+import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, exportSkillMap } from "@/api/skillmapApi";
 import { getMe } from "@/api/userApi";
 import { SkillMap } from "@/types/skillmap";
 import { User } from "@/types/user";
-import { BookOpen, LogOut } from "lucide-react";
+import { BookOpen, LogOut, Download } from "lucide-react";
 
 type MapStats = {
   skillCount: number;
@@ -31,6 +31,10 @@ const SkillMapsPage: React.FC = () => {
   const { clear: clearId } = useLocalStorage<string>("id", "");
   const [showJoinInput, setShowJoinInput] = useState(false);
   const [inviteCode, setInviteCode] = useState("");
+
+  const handleExport = async (mapId: number) => {
+    await exportSkillMap(api, mapId);
+  };
 
   const handleLogout = async () => {
     try {
@@ -235,12 +239,21 @@ const SkillMapsPage: React.FC = () => {
 
             <div className={styles['sm-card-footer']}>
               <span className={styles['sm-continue']}>Continue Mapping &gt;</span>
-              <button
-                className={styles['sm-edit-btn']}
-                onClick={(e) => { e.stopPropagation(); router.push(`/skillmaps/${map.id}/edit`); }}
-              >
-                Edit
-              </button>
+              <div style={{ display: "flex", gap: "6px" }}>
+                <button
+                  className={styles['sm-edit-btn']}
+                  title="Export skill map"
+                  onClick={(e) => { e.stopPropagation(); handleExport(map.id); }}
+                >
+                  <Download size={13} />
+                </button>
+                <button
+                  className={styles['sm-edit-btn']}
+                  onClick={(e) => { e.stopPropagation(); router.push(`/skillmaps/${map.id}/edit`); }}
+                >
+                  Edit
+                </button>
+              </div>
             </div>
           </div>
         ))}

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -8,6 +8,7 @@ import { getMe } from "@/api/userApi";
 import { SkillMap } from "@/types/skillmap";
 import { User } from "@/types/user";
 import { BookOpen, LogOut, Download } from "lucide-react";
+import ExportModal from "@/skillmaps/[id]/components/ExportModal";
 
 type MapStats = {
   skillCount: number;
@@ -31,9 +32,21 @@ const SkillMapsPage: React.FC = () => {
   const { clear: clearId } = useLocalStorage<string>("id", "");
   const [showJoinInput, setShowJoinInput] = useState(false);
   const [inviteCode, setInviteCode] = useState("");
+  const [exportingMap, setExportingMap] = useState<SkillMap | null>(null);
 
-  const handleExport = async (mapId: number) => {
-    await exportSkillMap(api, mapId);
+  const handleExport = async (mapId: number, title: string) => {
+    try {
+      const blob = await exportSkillMap(api, mapId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${title}-export.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success("Skill map exported!");
+    } catch (err) {
+      toast.error((err as ApplicationError).details ?? "Failed to export skill map.");
+    }
   };
 
   const handleLogout = async () => {
@@ -243,7 +256,7 @@ const SkillMapsPage: React.FC = () => {
                 <button
                   className={styles['sm-edit-btn']}
                   title="Export skill map"
-                  onClick={(e) => { e.stopPropagation(); handleExport(map.id); }}
+                  onClick={(e) => { e.stopPropagation(); setExportingMap(map); }}
                 >
                   <Download size={13} />
                 </button>
@@ -305,6 +318,13 @@ const SkillMapsPage: React.FC = () => {
       )}
 
       </main>
+
+      <ExportModal
+        open={exportingMap !== null}
+        mapTitle={exportingMap?.title ?? ""}
+        onExport={() => handleExport(exportingMap!.id, exportingMap!.title)}
+        onClose={() => setExportingMap(null)}
+      />
     </div>
   );
 };

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -460,6 +460,55 @@
   overflow-y: auto;
 }
 
+/* Export modal */
+
+.export-modal-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.export-modal-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 24px;
+}
+
+.export-format-grid {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.export-format-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 24px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: transparent;
+}
+
+.export-format-card--selected {
+  border-color: var(--primary);
+  color: var(--primary-light);
+  background: rgba(233, 30, 140, 0.08);
+}
+
+.export-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
 /* Skill Detail Panel */
 
 .detail-panel {


### PR DESCRIPTION
- S18 Export: Added export button to the skill map overview nav and dashboard card. Clicking opens a confirmation modal with a JSON format card (extensible for future formats like PDF/PNG). On confirm, the map is downloaded as a JSON file via an authenticated GET request.
- S19 Import: Added an "Import Map" button to the dashboard that opens the OS file picker. The selected JSON file is uploaded via multipart/form-data. On success the user is redirected to the newly created map; on failure the backend validation error is shown in a toast.
- S13 fix(#47): Drag-and-drop validation errors now surface the backend's specific error message (e.g. "Prerequisite skill 'X' must be on a lower level") instead of a generic fallback.