### PR TITLE
feat: quiz creation, taking, and management (part of S15 + S16)

### DIFF
--- a/app/api/quizApi.ts
+++ b/app/api/quizApi.ts
@@ -1,0 +1,87 @@
+import { ApiService } from "./apiService";
+import { Quiz, QuizQuestion, QuizAnswer, AttemptResult } from "@/types/quiz";
+
+// ── Path helpers (update here when backend confirms routes) ────────────────
+const quizPath = (skillMapId: number, skillId: number) =>
+  `/skillmaps/${skillMapId}/skills/${skillId}/quiz`;
+const questionsPath = (quizId: number) => `/quizzes/${quizId}/quizQuestions`;
+const questionPath = (questionId: number) => `/quizQuestions/${questionId}`;
+const answersPath = (questionId: number) => `/quizQuestions/${questionId}/answers`;
+const answerPath = (answerId: number) => `/answers/${answerId}`;
+const attemptsPath = (quizId: number) => `/quizzes/${quizId}/attempts`;
+const latestAttemptPath = (quizId: number) => `/quizzes/${quizId}/attempts/me/latest`;
+
+// ── Quiz CRUD (lecturer) ───────────────────────────────────────────────────
+
+export function createQuiz(api: ApiService, skillMapId: number, skillId: number): Promise<Quiz> {
+  return api.post<Quiz>(quizPath(skillMapId, skillId), {});
+}
+
+export function deleteQuiz(api: ApiService, skillMapId: number, skillId: number): Promise<void> {
+  return api.delete<void>(quizPath(skillMapId, skillId));
+}
+
+// ── Questions (lecturer) ───────────────────────────────────────────────────
+
+export function getQuizQuestions(api: ApiService, quizId: number): Promise<QuizQuestion[]> {
+  return api.get<QuizQuestion[]>(questionsPath(quizId));
+}
+
+export function createQuizQuestion(
+  api: ApiService,
+  quizId: number,
+  data: { quizQuestionText: string; orderIndex: number },
+): Promise<QuizQuestion> {
+  return api.post<QuizQuestion>(questionsPath(quizId), data);
+}
+
+export function updateQuizQuestion(
+  api: ApiService,
+  questionId: number,
+  data: { quizQuestionText?: string; orderIndex?: number },
+): Promise<QuizQuestion> {
+  return api.patch<QuizQuestion>(questionPath(questionId), data);
+}
+
+export function deleteQuizQuestion(api: ApiService, questionId: number): Promise<void> {
+  return api.delete<void>(questionPath(questionId));
+}
+
+// ── Answers (lecturer) ─────────────────────────────────────────────────────
+
+export function createQuizAnswer(
+  api: ApiService,
+  questionId: number,
+  data: { answerText: string; isCorrect: boolean },
+): Promise<QuizAnswer> {
+  return api.post<QuizAnswer>(answersPath(questionId), data);
+}
+
+export function updateQuizAnswer(
+  api: ApiService,
+  answerId: number,
+  data: { answerText?: string; isCorrect?: boolean },
+): Promise<QuizAnswer> {
+  return api.patch<QuizAnswer>(answerPath(answerId), data);
+}
+
+export function deleteQuizAnswer(api: ApiService, answerId: number): Promise<void> {
+  return api.delete<void>(answerPath(answerId));
+}
+
+// ── Attempts (student) ─────────────────────────────────────────────────────
+
+export function getLatestAttempt(
+  api: ApiService,
+  quizId: number,
+): Promise<AttemptResult | null> {
+  return api.get<AttemptResult | null>(latestAttemptPath(quizId));
+}
+
+export function submitAttempt(
+  api: ApiService,
+  quizId: number,
+  data: { answers: { quizQuestionId: number; selectedAnswerId: number }[] },
+): Promise<AttemptResult> {
+  return api.post<AttemptResult>(attemptsPath(quizId), data);
+}

--- a/app/api/quizApi.ts
+++ b/app/api/quizApi.ts
@@ -1,65 +1,54 @@
 import { ApiService } from "./apiService";
-import { Quiz, QuizQuestion, QuizAnswer, AttemptResult } from "@/types/quiz";
+import { Quiz, QuizQuestion, QuizAnswer, QuizAttempt } from "@/types/quiz";
 
-// ── Path helpers (update here when backend confirms routes) ────────────────
-const quizPath = (skillMapId: number, skillId: number) =>
-  `/skillmaps/${skillMapId}/skills/${skillId}/quiz`;
+// ── Path helpers ─────────────────────────────────────────────────────────────
+const quizPath = (skillId: number) => `/skills/${skillId}/quiz`;
+const quizByIdPath = (quizId: number) => `/quizzes/${quizId}`;
 const questionsPath = (quizId: number) => `/quizzes/${quizId}/quizQuestions`;
 const questionPath = (questionId: number) => `/quizQuestions/${questionId}`;
 const answersPath = (questionId: number) => `/quizQuestions/${questionId}/answers`;
 const answerPath = (answerId: number) => `/answers/${answerId}`;
 const attemptsPath = (quizId: number) => `/quizzes/${quizId}/attempts`;
 const latestAttemptPath = (quizId: number) => `/quizzes/${quizId}/attempts/me/latest`;
+const attemptPath = (attemptId: number) => `/attempts/${attemptId}`;
+const submitAttemptPath = (attemptId: number) => `/attempts/${attemptId}/submit`;
 
-// ── Mock mode (flip to false when backend routes are confirmed) ────────────
-const MOCK_MODE = true;
+// ── Quiz CRUD (owner) ─────────────────────────────────────────────────────────
 
-const MOCK_QUESTIONS: QuizQuestion[] = [
-  {
-    id: 1,
-    quizId: 1,
-    quizQuestionText: "What is React?",
-    orderIndex: 0,
-    answers: [
-      { id: 1, quizQuestionId: 1, answerText: "A JavaScript library for building UIs", isCorrect: true },
-      { id: 2, quizQuestionId: 1, answerText: "A CSS framework", isCorrect: false },
-      { id: 3, quizQuestionId: 1, answerText: "A backend framework", isCorrect: false },
-    ],
-  },
-  {
-    id: 2,
-    quizId: 1,
-    quizQuestionText: "Which hook manages side effects in React?",
-    orderIndex: 1,
-    answers: [
-      { id: 4, quizQuestionId: 2, answerText: "useState", isCorrect: false },
-      { id: 5, quizQuestionId: 2, answerText: "useEffect", isCorrect: true },
-      { id: 6, quizQuestionId: 2, answerText: "useRef", isCorrect: false },
-    ],
-  },
-];
-
-function mockDelay<T>(value: T): Promise<T> {
-  return new Promise((resolve) => setTimeout(() => resolve(value), 300));
+export function getQuiz(api: ApiService, skillId: number): Promise<Quiz> {
+  return api.get<Quiz>(quizPath(skillId));
 }
 
-// ── Quiz CRUD (lecturer) ───────────────────────────────────────────────────
-
-export function createQuiz(api: ApiService, skillMapId: number, skillId: number): Promise<Quiz> {
-  if (MOCK_MODE) return mockDelay({ id: 1, skillId });
-  return api.post<Quiz>(quizPath(skillMapId, skillId), {});
+export function createQuiz(
+  api: ApiService,
+  skillId: number,
+  data?: { isActive?: boolean; cooldownHours?: number; passMark?: number },
+): Promise<Quiz> {
+  return api.post<Quiz>(quizPath(skillId), data ?? {});
 }
 
-export function deleteQuiz(api: ApiService, skillMapId: number, skillId: number): Promise<void> {
-  if (MOCK_MODE) return mockDelay(undefined as void);
-  return api.delete<void>(quizPath(skillMapId, skillId));
+export function updateQuiz(
+  api: ApiService,
+  quizId: number,
+  data: { isActive?: boolean; cooldownHours?: number; passMark?: number },
+): Promise<Quiz> {
+  return api.patch<Quiz>(quizByIdPath(quizId), data);
 }
 
-// ── Questions (lecturer) ───────────────────────────────────────────────────
+export function deleteQuiz(api: ApiService, quizId: number): Promise<void> {
+  return api.delete<void>(quizByIdPath(quizId));
+}
 
-export function getQuizQuestions(api: ApiService, quizId: number): Promise<QuizQuestion[]> {
-  if (MOCK_MODE) return mockDelay([...MOCK_QUESTIONS]);
-  return api.get<QuizQuestion[]>(questionsPath(quizId));
+// ── Questions (owner write, member read) ──────────────────────────────────────
+
+export async function getQuizQuestions(api: ApiService, quizId: number): Promise<QuizQuestion[]> {
+  const questions = await api.get<Omit<QuizQuestion, "answers">[]>(questionsPath(quizId));
+  return Promise.all(
+    questions.map(async (q) => ({
+      ...q,
+      answers: await api.get<QuizAnswer[]>(answersPath(q.id)),
+    })),
+  );
 }
 
 export function createQuizQuestion(
@@ -67,7 +56,6 @@ export function createQuizQuestion(
   quizId: number,
   data: { quizQuestionText: string; orderIndex: number },
 ): Promise<QuizQuestion> {
-  if (MOCK_MODE) return mockDelay({ id: Date.now(), quizId, ...data, answers: [] });
   return api.post<QuizQuestion>(questionsPath(quizId), data);
 }
 
@@ -76,26 +64,20 @@ export function updateQuizQuestion(
   questionId: number,
   data: { quizQuestionText?: string; orderIndex?: number },
 ): Promise<QuizQuestion> {
-  if (MOCK_MODE) {
-    const q = MOCK_QUESTIONS.find((q) => q.id === questionId);
-    return mockDelay({ ...(q ?? MOCK_QUESTIONS[0]), ...data });
-  }
   return api.patch<QuizQuestion>(questionPath(questionId), data);
 }
 
 export function deleteQuizQuestion(api: ApiService, questionId: number): Promise<void> {
-  if (MOCK_MODE) return mockDelay(undefined as void);
   return api.delete<void>(questionPath(questionId));
 }
 
-// ── Answers (lecturer) ─────────────────────────────────────────────────────
+// ── Answers (owner write, member read) ───────────────────────────────────────
 
 export function createQuizAnswer(
   api: ApiService,
   questionId: number,
   data: { answerText: string; isCorrect: boolean },
 ): Promise<QuizAnswer> {
-  if (MOCK_MODE) return mockDelay({ id: Date.now(), quizQuestionId: questionId, ...data });
   return api.post<QuizAnswer>(answersPath(questionId), data);
 }
 
@@ -104,38 +86,43 @@ export function updateQuizAnswer(
   answerId: number,
   data: { answerText?: string; isCorrect?: boolean },
 ): Promise<QuizAnswer> {
-  if (MOCK_MODE) return mockDelay({ id: answerId, quizQuestionId: 0, answerText: "", isCorrect: false, ...data });
   return api.patch<QuizAnswer>(answerPath(answerId), data);
 }
 
 export function deleteQuizAnswer(api: ApiService, answerId: number): Promise<void> {
-  if (MOCK_MODE) return mockDelay(undefined as void);
   return api.delete<void>(answerPath(answerId));
 }
 
-// ── Attempts (student) ─────────────────────────────────────────────────────
+// ── Attempts (member) ─────────────────────────────────────────────────────────
 
-export function getLatestAttempt(
-  api: ApiService,
-  quizId: number,
-): Promise<AttemptResult | null> {
-  if (MOCK_MODE) return mockDelay(null); // null = student hasn't taken it yet
-  return api.get<AttemptResult | null>(latestAttemptPath(quizId));
+// Step 1 of two-step submit: creates an unsubmitted attempt (passed === null)
+export function createAttempt(api: ApiService, quizId: number): Promise<QuizAttempt> {
+  return api.post<QuizAttempt>(attemptsPath(quizId), {});
 }
 
+// Step 2 of two-step submit: send answers to the attempt created above
 export function submitAttempt(
   api: ApiService,
-  quizId: number,
+  attemptId: number,
   data: { answers: { quizQuestionId: number; selectedAnswerId: number }[] },
-): Promise<AttemptResult> {
-  if (MOCK_MODE) {
-    const gradedAnswers = data.answers.map(({ quizQuestionId, selectedAnswerId }) => {
-      const question = MOCK_QUESTIONS.find((q) => q.id === quizQuestionId);
-      const answer = question?.answers.find((a) => a.id === selectedAnswerId);
-      return { quizQuestionId, selectedAnswerId, isCorrect: answer?.isCorrect ?? false };
-    });
-    const score = gradedAnswers.filter((a) => a.isCorrect).length;
-    return mockDelay({ id: Date.now(), score, answers: gradedAnswers });
+): Promise<QuizAttempt> {
+  return api.post<QuizAttempt>(submitAttemptPath(attemptId), data);
+}
+
+export async function getLatestAttempt(
+  api: ApiService,
+  quizId: number,
+): Promise<QuizAttempt | null> {
+  try {
+    return await api.get<QuizAttempt>(latestAttemptPath(quizId));
+  } catch (e) {
+    if (typeof e === "object" && e !== null && (e as { status?: number }).status === 404) {
+      return null;
+    }
+    throw e;
   }
-  return api.post<AttemptResult>(attemptsPath(quizId), data);
+}
+
+export function getAttempt(api: ApiService, attemptId: number): Promise<QuizAttempt> {
+  return api.get<QuizAttempt>(attemptPath(attemptId));
 }

--- a/app/api/quizApi.ts
+++ b/app/api/quizApi.ts
@@ -11,19 +11,54 @@ const answerPath = (answerId: number) => `/answers/${answerId}`;
 const attemptsPath = (quizId: number) => `/quizzes/${quizId}/attempts`;
 const latestAttemptPath = (quizId: number) => `/quizzes/${quizId}/attempts/me/latest`;
 
+// ── Mock mode (flip to false when backend routes are confirmed) ────────────
+const MOCK_MODE = true;
+
+const MOCK_QUESTIONS: QuizQuestion[] = [
+  {
+    id: 1,
+    quizId: 1,
+    quizQuestionText: "What is React?",
+    orderIndex: 0,
+    answers: [
+      { id: 1, quizQuestionId: 1, answerText: "A JavaScript library for building UIs", isCorrect: true },
+      { id: 2, quizQuestionId: 1, answerText: "A CSS framework", isCorrect: false },
+      { id: 3, quizQuestionId: 1, answerText: "A backend framework", isCorrect: false },
+    ],
+  },
+  {
+    id: 2,
+    quizId: 1,
+    quizQuestionText: "Which hook manages side effects in React?",
+    orderIndex: 1,
+    answers: [
+      { id: 4, quizQuestionId: 2, answerText: "useState", isCorrect: false },
+      { id: 5, quizQuestionId: 2, answerText: "useEffect", isCorrect: true },
+      { id: 6, quizQuestionId: 2, answerText: "useRef", isCorrect: false },
+    ],
+  },
+];
+
+function mockDelay<T>(value: T): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), 300));
+}
+
 // ── Quiz CRUD (lecturer) ───────────────────────────────────────────────────
 
 export function createQuiz(api: ApiService, skillMapId: number, skillId: number): Promise<Quiz> {
+  if (MOCK_MODE) return mockDelay({ id: 1, skillId });
   return api.post<Quiz>(quizPath(skillMapId, skillId), {});
 }
 
 export function deleteQuiz(api: ApiService, skillMapId: number, skillId: number): Promise<void> {
+  if (MOCK_MODE) return mockDelay(undefined as void);
   return api.delete<void>(quizPath(skillMapId, skillId));
 }
 
 // ── Questions (lecturer) ───────────────────────────────────────────────────
 
 export function getQuizQuestions(api: ApiService, quizId: number): Promise<QuizQuestion[]> {
+  if (MOCK_MODE) return mockDelay([...MOCK_QUESTIONS]);
   return api.get<QuizQuestion[]>(questionsPath(quizId));
 }
 
@@ -32,6 +67,7 @@ export function createQuizQuestion(
   quizId: number,
   data: { quizQuestionText: string; orderIndex: number },
 ): Promise<QuizQuestion> {
+  if (MOCK_MODE) return mockDelay({ id: Date.now(), quizId, ...data, answers: [] });
   return api.post<QuizQuestion>(questionsPath(quizId), data);
 }
 
@@ -40,10 +76,15 @@ export function updateQuizQuestion(
   questionId: number,
   data: { quizQuestionText?: string; orderIndex?: number },
 ): Promise<QuizQuestion> {
+  if (MOCK_MODE) {
+    const q = MOCK_QUESTIONS.find((q) => q.id === questionId);
+    return mockDelay({ ...(q ?? MOCK_QUESTIONS[0]), ...data });
+  }
   return api.patch<QuizQuestion>(questionPath(questionId), data);
 }
 
 export function deleteQuizQuestion(api: ApiService, questionId: number): Promise<void> {
+  if (MOCK_MODE) return mockDelay(undefined as void);
   return api.delete<void>(questionPath(questionId));
 }
 
@@ -54,6 +95,7 @@ export function createQuizAnswer(
   questionId: number,
   data: { answerText: string; isCorrect: boolean },
 ): Promise<QuizAnswer> {
+  if (MOCK_MODE) return mockDelay({ id: Date.now(), quizQuestionId: questionId, ...data });
   return api.post<QuizAnswer>(answersPath(questionId), data);
 }
 
@@ -62,10 +104,12 @@ export function updateQuizAnswer(
   answerId: number,
   data: { answerText?: string; isCorrect?: boolean },
 ): Promise<QuizAnswer> {
+  if (MOCK_MODE) return mockDelay({ id: answerId, quizQuestionId: 0, answerText: "", isCorrect: false, ...data });
   return api.patch<QuizAnswer>(answerPath(answerId), data);
 }
 
 export function deleteQuizAnswer(api: ApiService, answerId: number): Promise<void> {
+  if (MOCK_MODE) return mockDelay(undefined as void);
   return api.delete<void>(answerPath(answerId));
 }
 
@@ -75,6 +119,7 @@ export function getLatestAttempt(
   api: ApiService,
   quizId: number,
 ): Promise<AttemptResult | null> {
+  if (MOCK_MODE) return mockDelay(null); // null = student hasn't taken it yet
   return api.get<AttemptResult | null>(latestAttemptPath(quizId));
 }
 
@@ -83,5 +128,14 @@ export function submitAttempt(
   quizId: number,
   data: { answers: { quizQuestionId: number; selectedAnswerId: number }[] },
 ): Promise<AttemptResult> {
+  if (MOCK_MODE) {
+    const gradedAnswers = data.answers.map(({ quizQuestionId, selectedAnswerId }) => {
+      const question = MOCK_QUESTIONS.find((q) => q.id === quizQuestionId);
+      const answer = question?.answers.find((a) => a.id === selectedAnswerId);
+      return { quizQuestionId, selectedAnswerId, isCorrect: answer?.isCorrect ?? false };
+    });
+    const score = gradedAnswers.filter((a) => a.isCorrect).length;
+    return mockDelay({ id: Date.now(), score, answers: gradedAnswers });
+  }
   return api.post<AttemptResult>(attemptsPath(quizId), data);
 }

--- a/app/skillmaps/[id]/components/QuizEditorModal.tsx
+++ b/app/skillmaps/[id]/components/QuizEditorModal.tsx
@@ -35,7 +35,6 @@ type LocalQuestion = {
 type Props = {
   api: ApiService;
   open: boolean;
-  skillMapId: number;
   skillId: number;
   quizId: number | null;
   onClose: () => void;
@@ -92,7 +91,6 @@ const DeleteQuizButton: React.FC<{ onDelete: () => void; disabled: boolean }> = 
 const QuizEditorModal: React.FC<Props> = ({
   api,
   open,
-  skillMapId,
   skillId,
   quizId,
   onClose,
@@ -121,13 +119,13 @@ const QuizEditorModal: React.FC<Props> = ({
         const loaded: LocalQuestion[] = qs.map((q) => {
           qIds.add(q.id);
           const answerIdSet = new Set<number>();
-          const answers: LocalAnswer[] = (q.answers ?? []).map((a) => {
+          const answers: LocalAnswer[] = q.answers.map((a) => {
             answerIdSet.add(a.id);
             return {
               key: String(a.id),
               id: a.id,
               answerText: a.answerText,
-              isCorrect: a.isCorrect ?? false,
+              isCorrect: a.isCorrect,
             };
           });
           aIds.set(q.id, answerIdSet);

--- a/app/skillmaps/[id]/components/QuizEditorModal.tsx
+++ b/app/skillmaps/[id]/components/QuizEditorModal.tsx
@@ -17,22 +17,19 @@ import {
   updateQuizAnswer,
   deleteQuizAnswer,
 } from "@/api/quizApi";
-import { generateUUID } from "@/utils/uuid";
 import styles from "@/styles/skillmaps.module.css";
-
-type LocalAnswer = {
-  key: string;
-  id?: number;
-  answerText: string;
-  isCorrect: boolean;
-};
-
-type LocalQuestion = {
-  key: string;
-  id?: number;
-  quizQuestionText: string;
-  answers: LocalAnswer[];
-};
+import {
+  LocalQuestion,
+  emptyQuestion,
+  validate,
+  updateQuestionText,
+  removeQuestion,
+  addQuestion,
+  updateAnswerText,
+  setCorrectAnswer,
+  removeAnswer,
+  addAnswer,
+} from "./quizUtils";
 
 type Props = {
   api: ApiService;
@@ -41,53 +38,6 @@ type Props = {
   quizId: number | null;
   onClose: () => void;
   onSaved: (quiz: SkillQuizRef | null) => void;
-};
-
-function emptyAnswer(): LocalAnswer {
-  return { key: generateUUID(), answerText: "", isCorrect: false };
-}
-
-function emptyQuestion(): LocalQuestion {
-  return { key: generateUUID(), quizQuestionText: "", answers: [emptyAnswer()] };
-}
-
-const DeleteQuizButton: React.FC<{ onDelete: () => void; disabled: boolean }> = ({
-  onDelete,
-  disabled,
-}) => {
-  const [confirming, setConfirming] = useState(false);
-  if (!confirming) {
-    return (
-      <button
-        type="button"
-        className={styles["btn-delete"]}
-        onClick={() => setConfirming(true)}
-        disabled={disabled}
-        style={{ marginTop: 0, width: "auto", padding: "10px 20px" }}
-      >
-        Delete Quiz
-      </button>
-    );
-  }
-  return (
-    <div className={styles["btn-delete-row"]}>
-      <button
-        type="button"
-        className={`btn-ghost ${styles["btn-delete-cancel"]}`}
-        onClick={() => setConfirming(false)}
-      >
-        Cancel
-      </button>
-      <button
-        type="button"
-        className={styles["btn-delete"]}
-        onClick={onDelete}
-        style={{ marginTop: 0 }}
-      >
-        Confirm Delete
-      </button>
-    </div>
-  );
 };
 
 const QuizEditorModal: React.FC<Props> = ({
@@ -127,7 +77,7 @@ const QuizEditorModal: React.FC<Props> = ({
         const loaded: LocalQuestion[] = qs.map((q) => {
           qIds.add(q.id);
           const answerIdSet = new Set<number>();
-          const answers: LocalAnswer[] = q.answers.map((a) => {
+          const answers = q.answers.map((a) => {
             answerIdSet.add(a.id);
             return {
               key: String(a.id),
@@ -154,70 +104,8 @@ const QuizEditorModal: React.FC<Props> = ({
 
   if (!open) return null;
 
-  // ── question helpers ───────────────────────────────────────────────────
-
-  const updateQuestionText = (key: string, text: string) =>
-    setQuestions((qs) =>
-      qs.map((q) => (q.key === key ? { ...q, quizQuestionText: text } : q))
-    );
-
-  const removeQuestion = (key: string) =>
-    setQuestions((qs) => qs.filter((q) => q.key !== key));
-
-  const addQuestion = () => setQuestions((qs) => [...qs, emptyQuestion()]);
-
-  // ── answer helpers ─────────────────────────────────────────────────────
-
-  const updateAnswerText = (qKey: string, aKey: string, text: string) =>
-    setQuestions((qs) =>
-      qs.map((q) =>
-        q.key !== qKey
-          ? q
-          : { ...q, answers: q.answers.map((a) => (a.key === aKey ? { ...a, answerText: text } : a)) }
-      )
-    );
-
-  const setCorrect = (qKey: string, aKey: string) =>
-    setQuestions((qs) =>
-      qs.map((q) =>
-        q.key !== qKey
-          ? q
-          : { ...q, answers: q.answers.map((a) => ({ ...a, isCorrect: a.key === aKey })) }
-      )
-    );
-
-  const removeAnswer = (qKey: string, aKey: string) =>
-    setQuestions((qs) =>
-      qs.map((q) =>
-        q.key !== qKey ? q : { ...q, answers: q.answers.filter((a) => a.key !== aKey) }
-      )
-    );
-
-  const addAnswer = (qKey: string) =>
-    setQuestions((qs) =>
-      qs.map((q) => (q.key === qKey ? { ...q, answers: [...q.answers, emptyAnswer()] } : q))
-    );
-
-  // ── validation ─────────────────────────────────────────────────────────
-
-  const validate = (): string | null => {
-    if (questions.length === 0) return "Add at least one question.";
-    for (const q of questions) {
-      if (!q.quizQuestionText.trim()) return "All questions must have text.";
-      if (q.answers.length === 0) return "Each question must have at least one answer.";
-      for (const a of q.answers) {
-        if (!a.answerText.trim()) return "All answers must have text.";
-      }
-      if (!q.answers.some((a) => a.isCorrect))
-        return "Each question must have one correct answer marked.";
-    }
-    return null;
-  };
-
-  // ── save ───────────────────────────────────────────────────────────────
-
   const handleSave = async () => {
-    const err = validate();
+    const err = validate(questions);
     if (err) { toast.error(err); return; }
     setSaving(true);
     try {
@@ -230,7 +118,6 @@ const QuizEditorModal: React.FC<Props> = ({
         await updateQuiz(api, currentQuizId, { isActive, passMark });
       }
 
-      // Delete questions removed by the lecturer
       if (quizId !== null) {
         const keptIds = new Set(
           questions.map((q) => q.id).filter((id): id is number => id !== undefined)
@@ -251,7 +138,6 @@ const QuizEditorModal: React.FC<Props> = ({
           });
           questionId = q.id;
 
-          // Delete answers removed from this question
           const keptAnswerIds = new Set(
             q.answers.map((a) => a.id).filter((id): id is number => id !== undefined)
           );
@@ -289,8 +175,6 @@ const QuizEditorModal: React.FC<Props> = ({
       setSaving(false);
     }
   };
-
-  // ── delete quiz ────────────────────────────────────────────────────────
 
   const handleDeleteQuiz = async () => {
     try {
@@ -354,7 +238,7 @@ const QuizEditorModal: React.FC<Props> = ({
                     type="text"
                     placeholder={`Question ${qi + 1}`}
                     value={q.quizQuestionText}
-                    onChange={(e) => updateQuestionText(q.key, e.target.value)}
+                    onChange={(e) => setQuestions((qs) => updateQuestionText(qs, q.key, e.target.value))}
                   />
 
                   <div className={styles["quiz-answer-list"]}>
@@ -365,7 +249,7 @@ const QuizEditorModal: React.FC<Props> = ({
                           type="text"
                           placeholder="Answer"
                           value={a.answerText}
-                          onChange={(e) => updateAnswerText(q.key, a.key, e.target.value)}
+                          onChange={(e) => setQuestions((qs) => updateAnswerText(qs, q.key, a.key, e.target.value))}
                         />
                         <label
                           className={`${styles["quiz-correct-label"]} ${
@@ -376,14 +260,14 @@ const QuizEditorModal: React.FC<Props> = ({
                             type="radio"
                             name={`correct-${q.key}`}
                             checked={a.isCorrect}
-                            onChange={() => setCorrect(q.key, a.key)}
+                            onChange={() => setQuestions((qs) => setCorrectAnswer(qs, q.key, a.key))}
                           />
                           Correct
                         </label>
                         <button
                           type="button"
                           className={styles["quiz-icon-btn"]}
-                          onClick={() => removeAnswer(q.key, a.key)}
+                          onClick={() => setQuestions((qs) => removeAnswer(qs, q.key, a.key))}
                           aria-label="Remove answer"
                           disabled={q.answers.length === 1}
                         >
@@ -397,7 +281,7 @@ const QuizEditorModal: React.FC<Props> = ({
                     <button
                       type="button"
                       className={styles["quiz-add-answer-btn"]}
-                      onClick={() => addAnswer(q.key)}
+                      onClick={() => setQuestions((qs) => addAnswer(qs, q.key))}
                     >
                       + Add answer
                     </button>
@@ -405,7 +289,7 @@ const QuizEditorModal: React.FC<Props> = ({
                       <button
                         type="button"
                         className={styles["quiz-icon-btn"]}
-                        onClick={() => removeQuestion(q.key)}
+                        onClick={() => setQuestions((qs) => removeQuestion(qs, q.key))}
                         aria-label="Delete question"
                       >
                         Delete question
@@ -419,7 +303,7 @@ const QuizEditorModal: React.FC<Props> = ({
             <button
               type="button"
               className={`btn-ghost ${styles["quiz-modal-add-question"]}`}
-              onClick={addQuestion}
+              onClick={() => setQuestions((qs) => addQuestion(qs))}
             >
               + Add question
             </button>
@@ -448,3 +332,39 @@ const QuizEditorModal: React.FC<Props> = ({
 };
 
 export default QuizEditorModal;
+
+function DeleteQuizButton({ onDelete, disabled }: { onDelete: () => void; disabled: boolean }) {
+  const [confirming, setConfirming] = useState(false);
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        className={styles["btn-delete"]}
+        onClick={() => setConfirming(true)}
+        disabled={disabled}
+        style={{ marginTop: 0, width: "auto", padding: "10px 20px" }}
+      >
+        Delete Quiz
+      </button>
+    );
+  }
+  return (
+    <div className={styles["btn-delete-row"]}>
+      <button
+        type="button"
+        className={`btn-ghost ${styles["btn-delete-cancel"]}`}
+        onClick={() => setConfirming(false)}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        className={styles["btn-delete"]}
+        onClick={onDelete}
+        style={{ marginTop: 0 }}
+      >
+        Confirm Delete
+      </button>
+    </div>
+  );
+}

--- a/app/skillmaps/[id]/components/QuizEditorModal.tsx
+++ b/app/skillmaps/[id]/components/QuizEditorModal.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from "react";
+import toast from "react-hot-toast";
+import { ApiService } from "@/api/apiService";
+import { SkillQuizRef } from "@/types/skill";
+import {
+  createQuiz,
+  deleteQuiz,
+  getQuizQuestions,
+  createQuizQuestion,
+  updateQuizQuestion,
+  deleteQuizQuestion,
+  createQuizAnswer,
+  updateQuizAnswer,
+  deleteQuizAnswer,
+} from "@/api/quizApi";
+import { generateUUID } from "@/utils/uuid";
+import styles from "@/styles/skillmaps.module.css";
+
+type LocalAnswer = {
+  key: string;
+  id?: number;
+  answerText: string;
+  isCorrect: boolean;
+};
+
+type LocalQuestion = {
+  key: string;
+  id?: number;
+  quizQuestionText: string;
+  answers: LocalAnswer[];
+};
+
+type Props = {
+  api: ApiService;
+  open: boolean;
+  skillMapId: number;
+  skillId: number;
+  quizId: number | null;
+  onClose: () => void;
+  onSaved: (quiz: SkillQuizRef | null) => void;
+};
+
+function emptyAnswer(): LocalAnswer {
+  return { key: generateUUID(), answerText: "", isCorrect: false };
+}
+
+function emptyQuestion(): LocalQuestion {
+  return { key: generateUUID(), quizQuestionText: "", answers: [emptyAnswer()] };
+}
+
+const DeleteQuizButton: React.FC<{ onDelete: () => void; disabled: boolean }> = ({
+  onDelete,
+  disabled,
+}) => {
+  const [confirming, setConfirming] = useState(false);
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        className={styles["btn-delete"]}
+        onClick={() => setConfirming(true)}
+        disabled={disabled}
+        style={{ marginTop: 0, width: "auto", padding: "10px 20px" }}
+      >
+        Delete Quiz
+      </button>
+    );
+  }
+  return (
+    <div className={styles["btn-delete-row"]}>
+      <button
+        type="button"
+        className={`btn-ghost ${styles["btn-delete-cancel"]}`}
+        onClick={() => setConfirming(false)}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        className={styles["btn-delete"]}
+        onClick={onDelete}
+        style={{ marginTop: 0 }}
+      >
+        Confirm Delete
+      </button>
+    </div>
+  );
+};
+
+const QuizEditorModal: React.FC<Props> = ({
+  api,
+  open,
+  skillMapId,
+  skillId,
+  quizId,
+  onClose,
+  onSaved,
+}) => {
+  const [questions, setQuestions] = useState<LocalQuestion[]>([emptyQuestion()]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const origQuestionIds = useRef<Set<number>>(new Set());
+  const origAnswerIds = useRef<Map<number, Set<number>>>(new Map());
+
+  useEffect(() => {
+    if (!open) return;
+    if (quizId === null) {
+      setQuestions([emptyQuestion()]);
+      origQuestionIds.current = new Set();
+      origAnswerIds.current = new Map();
+      return;
+    }
+    setLoading(true);
+    getQuizQuestions(api, quizId)
+      .then((qs) => {
+        const qIds = new Set<number>();
+        const aIds = new Map<number, Set<number>>();
+        const loaded: LocalQuestion[] = qs.map((q) => {
+          qIds.add(q.id);
+          const answerIdSet = new Set<number>();
+          const answers: LocalAnswer[] = (q.answers ?? []).map((a) => {
+            answerIdSet.add(a.id);
+            return {
+              key: String(a.id),
+              id: a.id,
+              answerText: a.answerText,
+              isCorrect: a.isCorrect ?? false,
+            };
+          });
+          aIds.set(q.id, answerIdSet);
+          return {
+            key: String(q.id),
+            id: q.id,
+            quizQuestionText: q.quizQuestionText,
+            answers,
+          };
+        });
+        origQuestionIds.current = qIds;
+        origAnswerIds.current = aIds;
+        setQuestions(loaded.length > 0 ? loaded : [emptyQuestion()]);
+      })
+      .catch(() => toast.error("Failed to load quiz."))
+      .finally(() => setLoading(false));
+  }, [open, quizId]);
+
+  if (!open) return null;
+
+  // ── question helpers ───────────────────────────────────────────────────
+
+  const updateQuestionText = (key: string, text: string) =>
+    setQuestions((qs) =>
+      qs.map((q) => (q.key === key ? { ...q, quizQuestionText: text } : q))
+    );
+
+  const removeQuestion = (key: string) =>
+    setQuestions((qs) => qs.filter((q) => q.key !== key));
+
+  const addQuestion = () => setQuestions((qs) => [...qs, emptyQuestion()]);
+
+  // ── answer helpers ─────────────────────────────────────────────────────
+
+  const updateAnswerText = (qKey: string, aKey: string, text: string) =>
+    setQuestions((qs) =>
+      qs.map((q) =>
+        q.key !== qKey
+          ? q
+          : { ...q, answers: q.answers.map((a) => (a.key === aKey ? { ...a, answerText: text } : a)) }
+      )
+    );
+
+  const setCorrect = (qKey: string, aKey: string) =>
+    setQuestions((qs) =>
+      qs.map((q) =>
+        q.key !== qKey
+          ? q
+          : { ...q, answers: q.answers.map((a) => ({ ...a, isCorrect: a.key === aKey })) }
+      )
+    );
+
+  const removeAnswer = (qKey: string, aKey: string) =>
+    setQuestions((qs) =>
+      qs.map((q) =>
+        q.key !== qKey ? q : { ...q, answers: q.answers.filter((a) => a.key !== aKey) }
+      )
+    );
+
+  const addAnswer = (qKey: string) =>
+    setQuestions((qs) =>
+      qs.map((q) => (q.key === qKey ? { ...q, answers: [...q.answers, emptyAnswer()] } : q))
+    );
+
+  // ── validation ─────────────────────────────────────────────────────────
+
+  const validate = (): string | null => {
+    if (questions.length === 0) return "Add at least one question.";
+    for (const q of questions) {
+      if (!q.quizQuestionText.trim()) return "All questions must have text.";
+      if (q.answers.length === 0) return "Each question must have at least one answer.";
+      for (const a of q.answers) {
+        if (!a.answerText.trim()) return "All answers must have text.";
+      }
+      if (!q.answers.some((a) => a.isCorrect))
+        return "Each question must have one correct answer marked.";
+    }
+    return null;
+  };
+
+  // ── save ───────────────────────────────────────────────────────────────
+
+  const handleSave = async () => {
+    const err = validate();
+    if (err) { toast.error(err); return; }
+    setSaving(true);
+    try {
+      let currentQuizId = quizId;
+
+      if (currentQuizId === null) {
+        const quiz = await createQuiz(api, skillMapId, skillId);
+        currentQuizId = quiz.id;
+      }
+
+      // Delete questions removed by the lecturer
+      if (quizId !== null) {
+        const keptIds = new Set(
+          questions.map((q) => q.id).filter((id): id is number => id !== undefined)
+        );
+        for (const origId of origQuestionIds.current) {
+          if (!keptIds.has(origId)) await deleteQuizQuestion(api, origId);
+        }
+      }
+
+      for (let i = 0; i < questions.length; i++) {
+        const q = questions[i];
+        let questionId: number;
+
+        if (q.id !== undefined) {
+          await updateQuizQuestion(api, q.id, {
+            quizQuestionText: q.quizQuestionText,
+            orderIndex: i,
+          });
+          questionId = q.id;
+
+          // Delete answers removed from this question
+          const keptAnswerIds = new Set(
+            q.answers.map((a) => a.id).filter((id): id is number => id !== undefined)
+          );
+          for (const origId of origAnswerIds.current.get(q.id) ?? []) {
+            if (!keptAnswerIds.has(origId)) await deleteQuizAnswer(api, origId);
+          }
+        } else {
+          const created = await createQuizQuestion(api, currentQuizId, {
+            quizQuestionText: q.quizQuestionText,
+            orderIndex: i,
+          });
+          questionId = created.id;
+        }
+
+        for (const a of q.answers) {
+          if (a.id !== undefined) {
+            await updateQuizAnswer(api, a.id, {
+              answerText: a.answerText,
+              isCorrect: a.isCorrect,
+            });
+          } else {
+            await createQuizAnswer(api, questionId, {
+              answerText: a.answerText,
+              isCorrect: a.isCorrect,
+            });
+          }
+        }
+      }
+
+      toast.success("Quiz saved.");
+      onSaved({ id: currentQuizId });
+    } catch {
+      toast.error("Failed to save quiz.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── delete quiz ────────────────────────────────────────────────────────
+
+  const handleDeleteQuiz = async () => {
+    try {
+      await deleteQuiz(api, skillMapId, skillId);
+      toast.success("Quiz deleted.");
+      onSaved(null);
+    } catch {
+      toast.error("Failed to delete quiz.");
+    }
+  };
+
+  return (
+    <div
+      className={styles["modal-backdrop"]}
+      role="button"
+      tabIndex={0}
+      aria-label="Close modal"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
+      <div
+        className={`${styles["modal"]} ${styles["modal--quiz"]}`}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <h2 className="form-heading">{quizId ? "Edit Quiz" : "Create Quiz"}</h2>
+
+        {loading ? (
+          <p className={styles["quiz-loading"]}>Loading…</p>
+        ) : (
+          <>
+            <div className={styles["quiz-question-list"]}>
+              {questions.map((q, qi) => (
+                <div key={q.key} className={styles["quiz-question-block"]}>
+                  <input
+                    className="auth-input"
+                    type="text"
+                    placeholder={`Question ${qi + 1}`}
+                    value={q.quizQuestionText}
+                    onChange={(e) => updateQuestionText(q.key, e.target.value)}
+                  />
+
+                  <div className={styles["quiz-answer-list"]}>
+                    {q.answers.map((a) => (
+                      <div key={a.key} className={styles["quiz-answer-row"]}>
+                        <input
+                          className={`auth-input ${styles["quiz-answer-input"]}`}
+                          type="text"
+                          placeholder="Answer"
+                          value={a.answerText}
+                          onChange={(e) => updateAnswerText(q.key, a.key, e.target.value)}
+                        />
+                        <label
+                          className={`${styles["quiz-correct-label"]} ${
+                            a.isCorrect ? styles["quiz-correct-label--active"] : ""
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name={`correct-${q.key}`}
+                            checked={a.isCorrect}
+                            onChange={() => setCorrect(q.key, a.key)}
+                          />
+                          Correct
+                        </label>
+                        <button
+                          type="button"
+                          className={styles["quiz-icon-btn"]}
+                          onClick={() => removeAnswer(q.key, a.key)}
+                          aria-label="Remove answer"
+                          disabled={q.answers.length === 1}
+                        >
+                          ×
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className={styles["quiz-question-footer"]}>
+                    <button
+                      type="button"
+                      className={styles["quiz-add-answer-btn"]}
+                      onClick={() => addAnswer(q.key)}
+                    >
+                      + Add answer
+                    </button>
+                    {questions.length > 1 && (
+                      <button
+                        type="button"
+                        className={styles["quiz-icon-btn"]}
+                        onClick={() => removeQuestion(q.key)}
+                        aria-label="Delete question"
+                      >
+                        Delete question
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              className={`btn-ghost ${styles["quiz-modal-add-question"]}`}
+              onClick={addQuestion}
+            >
+              + Add question
+            </button>
+
+            <div className={styles["quiz-modal-actions"]}>
+              <button
+                type="button"
+                className="btn-gradient"
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+              <button type="button" className="btn-ghost" onClick={onClose} disabled={saving}>
+                Cancel
+              </button>
+              {quizId !== null && (
+                <DeleteQuizButton onDelete={handleDeleteQuiz} disabled={saving} />
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QuizEditorModal;

--- a/app/skillmaps/[id]/components/QuizEditorModal.tsx
+++ b/app/skillmaps/[id]/components/QuizEditorModal.tsx
@@ -218,7 +218,7 @@ const QuizEditorModal: React.FC<Props> = ({
       let currentQuizId = quizId;
 
       if (currentQuizId === null) {
-        const quiz = await createQuiz(api, skillMapId, skillId);
+        const quiz = await createQuiz(api, skillId);
         currentQuizId = quiz.id;
       }
 
@@ -286,7 +286,7 @@ const QuizEditorModal: React.FC<Props> = ({
 
   const handleDeleteQuiz = async () => {
     try {
-      await deleteQuiz(api, skillMapId, skillId);
+      await deleteQuiz(api, quizId!);
       toast.success("Quiz deleted.");
       onSaved(null);
     } catch {

--- a/app/skillmaps/[id]/components/QuizEditorModal.tsx
+++ b/app/skillmaps/[id]/components/QuizEditorModal.tsx
@@ -5,7 +5,9 @@ import toast from "react-hot-toast";
 import { ApiService } from "@/api/apiService";
 import { SkillQuizRef } from "@/types/skill";
 import {
+  getQuiz,
   createQuiz,
+  updateQuiz,
   deleteQuiz,
   getQuizQuestions,
   createQuizQuestion,
@@ -97,6 +99,8 @@ const QuizEditorModal: React.FC<Props> = ({
   onSaved,
 }) => {
   const [questions, setQuestions] = useState<LocalQuestion[]>([emptyQuestion()]);
+  const [passMark, setPassMark] = useState(70);
+  const [isActive, setIsActive] = useState(true);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
 
@@ -107,13 +111,17 @@ const QuizEditorModal: React.FC<Props> = ({
     if (!open) return;
     if (quizId === null) {
       setQuestions([emptyQuestion()]);
+      setPassMark(70);
+      setIsActive(true);
       origQuestionIds.current = new Set();
       origAnswerIds.current = new Map();
       return;
     }
     setLoading(true);
-    getQuizQuestions(api, quizId)
-      .then((qs) => {
+    Promise.all([getQuiz(api, skillId), getQuizQuestions(api, quizId)])
+      .then(([quiz, qs]) => {
+        setPassMark(quiz.passMark);
+        setIsActive(quiz.isActive);
         const qIds = new Set<number>();
         const aIds = new Map<number, Set<number>>();
         const loaded: LocalQuestion[] = qs.map((q) => {
@@ -216,8 +224,10 @@ const QuizEditorModal: React.FC<Props> = ({
       let currentQuizId = quizId;
 
       if (currentQuizId === null) {
-        const quiz = await createQuiz(api, skillId);
+        const quiz = await createQuiz(api, skillId, { isActive, passMark });
         currentQuizId = quiz.id;
+      } else {
+        await updateQuiz(api, currentQuizId, { isActive, passMark });
       }
 
       // Delete questions removed by the lecturer
@@ -314,6 +324,28 @@ const QuizEditorModal: React.FC<Props> = ({
           <p className={styles["quiz-loading"]}>Loading…</p>
         ) : (
           <>
+            <div className={styles["quiz-settings-row"]}>
+              <label className={styles["quiz-settings-label"]}>
+                Pass mark (%)
+                <input
+                  className={`auth-input ${styles["quiz-settings-input"]}`}
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={passMark}
+                  onChange={(e) => setPassMark(Math.min(100, Math.max(0, Number(e.target.value))))}
+                />
+              </label>
+              <label className={styles["quiz-settings-label"]}>
+                <input
+                  type="checkbox"
+                  checked={isActive}
+                  onChange={(e) => setIsActive(e.target.checked)}
+                />
+                Active
+              </label>
+            </div>
+
             <div className={styles["quiz-question-list"]}>
               {questions.map((q, qi) => (
                 <div key={q.key} className={styles["quiz-question-block"]}>

--- a/app/skillmaps/[id]/components/QuizTakeModal.tsx
+++ b/app/skillmaps/[id]/components/QuizTakeModal.tsx
@@ -107,6 +107,7 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose, p
     if (result?.cooldownUntil) {
       const until = new Date(result.cooldownUntil);
       if (until > new Date()) {
+        // convert remaining ms into whole hours plus the leftover minutes
         const diffMs = until.getTime() - Date.now();
         const hours = Math.floor(diffMs / (1000 * 60 * 60));
         const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
@@ -137,158 +138,28 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose, p
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >
-        {phase === "loading" && <p className={styles["quiz-loading"]}>Loading…</p>}
-
-        {phase === "locked" && (
-          <>
-            <h2 className="form-heading">Quiz</h2>
-            <p className={styles["quiz-loading"]}>This quiz is currently inactive.</p>
-            <div className={styles["quiz-modal-actions"]}>
-              <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
-            </div>
-          </>
-        )}
-
-        {phase === "preview" && (
-          <>
-            <h2 className="form-heading">Quiz Preview</h2>
-            <div className={styles["quiz-question-list"]}>
-              {questions.map((q, qi) => (
-                <div key={q.id} className={styles["quiz-take-question"]}>
-                  <p className={styles["quiz-take-question-text"]}>
-                    {qi + 1}. {q.quizQuestionText}
-                  </p>
-                  <div className={styles["quiz-take-options"]}>
-                    {q.answers.map((a) => (
-                      <div key={a.id} className={styles["quiz-take-option"]}>
-                        <span>{a.answerText}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div className={styles["quiz-modal-actions"]}>
-              <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
-            </div>
-          </>
-        )}
-
+        {phase === "loading" && <LoadingPhase />}
+        {phase === "locked" && <LockedPhase onClose={onClose} />}
+        {phase === "preview" && <PreviewPhase questions={questions} onClose={onClose} />}
         {phase === "taking" && (
-          <>
-            <h2 className="form-heading">Quiz</h2>
-            <div className={styles["quiz-question-list"]}>
-              {questions.map((q, qi) => (
-                <div key={q.id} className={styles["quiz-take-question"]}>
-                  <p className={styles["quiz-take-question-text"]}>
-                    {qi + 1}. {q.quizQuestionText}
-                  </p>
-                  <div className={styles["quiz-take-options"]}>
-                    {q.answers.map((a) => {
-                      const selected = selections.get(q.id) === a.id;
-                      return (
-                        <label
-                          key={a.id}
-                          className={`${styles["quiz-take-option"]} ${
-                            selected ? styles["quiz-take-option--selected"] : ""
-                          }`}
-                        >
-                          <input
-                            type="radio"
-                            name={`q-${q.id}`}
-                            checked={selected}
-                            onChange={() =>
-                              setSelections((prev) => new Map(prev).set(q.id, a.id))
-                            }
-                          />
-                          <span>{a.answerText}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div className={styles["quiz-modal-actions"]}>
-              <button
-                type="button"
-                className="btn-gradient"
-                onClick={handleSubmit}
-                disabled={!allAnswered || submitting}
-              >
-                {submitting ? "Submitting…" : "Submit"}
-              </button>
-              <button type="button" className="btn-ghost" onClick={onClose} disabled={submitting}>
-                Cancel
-              </button>
-            </div>
-          </>
+          <TakingPhase
+            questions={questions}
+            selections={selections}
+            setSelections={setSelections}
+            allAnswered={allAnswered}
+            submitting={submitting}
+            onSubmit={handleSubmit}
+            onClose={onClose}
+          />
         )}
-
         {phase === "result" && result && (
-          <>
-            <h2 className="form-heading">Your Result</h2>
-            <p className={styles["quiz-result-score"]}>
-              Score: {result.score ?? "—"}% — {result.passed ? "Passed ✓" : "Failed ✗"}
-            </p>
-            {selections.size > 0 && (
-              <div className={styles["quiz-question-list"]}>
-                {questions.map((q, qi) => {
-                  const selectedId = selections.get(q.id);
-                  const selectedWasWrong =
-                    selectedId !== undefined &&
-                    !(q.answers.find((a) => a.id === selectedId)?.isCorrect ?? false);
-                  return (
-                    <div key={q.id} className={styles["quiz-take-question"]}>
-                      <p className={styles["quiz-take-question-text"]}>
-                        {qi + 1}. {q.quizQuestionText}
-                      </p>
-                      <div className={styles["quiz-take-options"]}>
-                        {q.answers.map((a) => {
-                          const wasSelected = selectedId === a.id;
-                          const showAsCorrect = wasSelected && a.isCorrect;
-                          const showAsWrong = wasSelected && !a.isCorrect;
-                          const showCorrectHint = !wasSelected && a.isCorrect && selectedWasWrong;
-                          return (
-                            <div
-                              key={a.id}
-                              className={`${styles["quiz-result-answer-row"]} ${
-                                showAsCorrect
-                                  ? styles["quiz-result-answer-row--correct"]
-                                  : showAsWrong
-                                    ? styles["quiz-result-answer-row--wrong"]
-                                    : ""
-                              }`}
-                            >
-                              <span>{a.answerText}</span>
-                              {wasSelected && (
-                                <span className={styles["quiz-result-your-answer"]}>
-                                  {a.isCorrect ? " ✓" : " ✗ your answer"}
-                                </span>
-                              )}
-                              {showCorrectHint && (
-                                <span className={styles["quiz-result-correct-hint"]}>
-                                  {" "}correct answer
-                                </span>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-            <div className={styles["quiz-modal-actions"]}>
-              <button type="button" className="btn-gradient" onClick={handleRetake}>
-                Retake
-              </button>
-              <button type="button" className="btn-ghost" onClick={onClose}>
-                Close
-              </button>
-            </div>
-          </>
+          <ResultPhase
+            result={result}
+            questions={questions}
+            selections={selections}
+            onRetake={handleRetake}
+            onClose={onClose}
+          />
         )}
       </div>
     </div>
@@ -296,3 +167,183 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose, p
 };
 
 export default QuizTakeModal;
+
+function LoadingPhase() {
+  return <p className={styles["quiz-loading"]}>Loading…</p>;
+}
+
+function LockedPhase({ onClose }: { onClose: () => void }) {
+  return (
+    <>
+      <h2 className="form-heading">Quiz</h2>
+      <p className={styles["quiz-loading"]}>This quiz is currently inactive.</p>
+      <div className={styles["quiz-modal-actions"]}>
+        <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
+      </div>
+    </>
+  );
+}
+
+function PreviewPhase({ questions, onClose }: { questions: QuizQuestion[]; onClose: () => void }) {
+  return (
+    <>
+      <h2 className="form-heading">Quiz Preview</h2>
+      <div className={styles["quiz-question-list"]}>
+        {questions.map((q, qi) => (
+          <div key={q.id} className={styles["quiz-take-question"]}>
+            <p className={styles["quiz-take-question-text"]}>
+              {qi + 1}. {q.quizQuestionText}
+            </p>
+            <div className={styles["quiz-take-options"]}>
+              {q.answers.map((a) => (
+                <div key={a.id} className={styles["quiz-take-option"]}>
+                  <span>{a.answerText}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles["quiz-modal-actions"]}>
+        <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
+      </div>
+    </>
+  );
+}
+
+type TakingPhaseProps = {
+  questions: QuizQuestion[];
+  selections: Map<number, number>;
+  setSelections: React.Dispatch<React.SetStateAction<Map<number, number>>>;
+  allAnswered: boolean;
+  submitting: boolean;
+  onSubmit: () => void;
+  onClose: () => void;
+};
+
+function TakingPhase({ questions, selections, setSelections, allAnswered, submitting, onSubmit, onClose }: TakingPhaseProps) {
+  return (
+    <>
+      <h2 className="form-heading">Quiz</h2>
+      <div className={styles["quiz-question-list"]}>
+        {questions.map((q, qi) => (
+          <div key={q.id} className={styles["quiz-take-question"]}>
+            <p className={styles["quiz-take-question-text"]}>
+              {qi + 1}. {q.quizQuestionText}
+            </p>
+            <div className={styles["quiz-take-options"]}>
+              {q.answers.map((a) => {
+                const selected = selections.get(q.id) === a.id;
+                return (
+                  <label
+                    key={a.id}
+                    className={`${styles["quiz-take-option"]} ${
+                      selected ? styles["quiz-take-option--selected"] : ""
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name={`q-${q.id}`}
+                      checked={selected}
+                      onChange={() => setSelections((prev) => new Map(prev).set(q.id, a.id))}
+                    />
+                    <span>{a.answerText}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles["quiz-modal-actions"]}>
+        <button
+          type="button"
+          className="btn-gradient"
+          onClick={onSubmit}
+          disabled={!allAnswered || submitting}
+        >
+          {submitting ? "Submitting…" : "Submit"}
+        </button>
+        <button type="button" className="btn-ghost" onClick={onClose} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+    </>
+  );
+}
+
+type ResultPhaseProps = {
+  result: QuizAttempt;
+  questions: QuizQuestion[];
+  selections: Map<number, number>;
+  onRetake: () => void;
+  onClose: () => void;
+};
+
+function ResultPhase({ result, questions, selections, onRetake, onClose }: ResultPhaseProps) {
+  return (
+    <>
+      <h2 className="form-heading">Your Result</h2>
+      <p className={styles["quiz-result-score"]}>
+        Score: {result.score ?? "—"}% — {result.passed ? "Passed ✓" : "Failed ✗"}
+      </p>
+      {selections.size > 0 && (
+        <div className={styles["quiz-question-list"]}>
+          {questions.map((q, qi) => {
+            const selectedId = selections.get(q.id);
+            const selectedWasWrong =
+              selectedId !== undefined &&
+              !(q.answers.find((a) => a.id === selectedId)?.isCorrect ?? false);
+            return (
+              <div key={q.id} className={styles["quiz-take-question"]}>
+                <p className={styles["quiz-take-question-text"]}>
+                  {qi + 1}. {q.quizQuestionText}
+                </p>
+                <div className={styles["quiz-take-options"]}>
+                  {q.answers.map((a) => {
+                    const wasSelected = selectedId === a.id;
+                    const showAsCorrect = wasSelected && a.isCorrect;
+                    const showAsWrong = wasSelected && !a.isCorrect;
+                    const showCorrectHint = !wasSelected && a.isCorrect && selectedWasWrong;
+                    return (
+                      <div
+                        key={a.id}
+                        className={`${styles["quiz-result-answer-row"]} ${
+                          showAsCorrect
+                            ? styles["quiz-result-answer-row--correct"]
+                            : showAsWrong
+                              ? styles["quiz-result-answer-row--wrong"]
+                              : ""
+                        }`}
+                      >
+                        <span>{a.answerText}</span>
+                        {wasSelected && (
+                          <span className={styles["quiz-result-your-answer"]}>
+                            {a.isCorrect ? " ✓" : " ✗ your answer"}
+                          </span>
+                        )}
+                        {showCorrectHint && (
+                          <span className={styles["quiz-result-correct-hint"]}>
+                            {" "}correct answer
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <div className={styles["quiz-modal-actions"]}>
+        <button type="button" className="btn-gradient" onClick={onRetake}>
+          Retake
+        </button>
+        <button type="button" className="btn-ghost" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </>
+  );
+}

--- a/app/skillmaps/[id]/components/QuizTakeModal.tsx
+++ b/app/skillmaps/[id]/components/QuizTakeModal.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import toast from "react-hot-toast";
 import { ApiService } from "@/api/apiService";
-import { QuizQuestion, AttemptResult } from "@/types/quiz";
+import { QuizQuestion, QuizAttempt } from "@/types/quiz";
 import { getLatestAttempt, getQuizQuestions, submitAttempt } from "@/api/quizApi";
 import styles from "@/styles/skillmaps.module.css";
 
@@ -20,7 +20,7 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
   const [phase, setPhase] = useState<Phase>("loading");
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [selections, setSelections] = useState<Map<number, number>>(new Map());
-  const [result, setResult] = useState<AttemptResult | null>(null);
+  const [result, setResult] = useState<QuizAttempt | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -75,8 +75,6 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
     setPhase("taking");
   };
 
-  const getResultAnswer = (questionId: number) =>
-    result?.answers.find((a) => a.quizQuestionId === questionId);
 
   return (
     <div
@@ -151,57 +149,57 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
           <>
             <h2 className="form-heading">Your Result</h2>
             <p className={styles["quiz-result-score"]}>
-              {result.score} / {questions.length} correct
+              Score: {result.score ?? "—"}% — {result.passed ? "Passed ✓" : "Failed ✗"}
             </p>
-            <div className={styles["quiz-question-list"]}>
-              {questions.map((q, qi) => {
-                const resultAnswer = getResultAnswer(q.id);
-                return (
-                  <div key={q.id} className={styles["quiz-take-question"]}>
-                    <p className={styles["quiz-take-question-text"]}>
-                      {qi + 1}. {q.quizQuestionText}
-                    </p>
-                    <div className={styles["quiz-take-options"]}>
-                      {q.answers.map((a) => {
-                        const wasSelected = resultAnswer?.selectedAnswerId === a.id;
-                        // isCorrect may be present if backend exposes it post-submission
-                        const isCorrectAnswer = a.isCorrect === true;
-                        const showAsWrongSelected =
-                          wasSelected && resultAnswer && !resultAnswer.isCorrect;
-                        const showAsCorrect =
-                          (wasSelected && resultAnswer?.isCorrect) ||
-                          (isCorrectAnswer && showAsWrongSelected);
-
-                        return (
-                          <div
-                            key={a.id}
-                            className={`${styles["quiz-result-answer-row"]} ${
-                              showAsCorrect
-                                ? styles["quiz-result-answer-row--correct"]
-                                : showAsWrongSelected
-                                  ? styles["quiz-result-answer-row--wrong"]
-                                  : ""
-                            }`}
-                          >
-                            <span>{a.answerText}</span>
-                            {wasSelected && (
-                              <span className={styles["quiz-result-your-answer"]}>
-                                {resultAnswer?.isCorrect ? " ✓" : " ✗ your answer"}
-                              </span>
-                            )}
-                            {isCorrectAnswer && showAsWrongSelected && (
-                              <span className={styles["quiz-result-correct-hint"]}>
-                                {" "}correct answer
-                              </span>
-                            )}
-                          </div>
-                        );
-                      })}
+            {selections.size > 0 && (
+              <div className={styles["quiz-question-list"]}>
+                {questions.map((q, qi) => {
+                  const selectedId = selections.get(q.id);
+                  const selectedWasWrong =
+                    selectedId !== undefined &&
+                    !(q.answers.find((a) => a.id === selectedId)?.isCorrect ?? false);
+                  return (
+                    <div key={q.id} className={styles["quiz-take-question"]}>
+                      <p className={styles["quiz-take-question-text"]}>
+                        {qi + 1}. {q.quizQuestionText}
+                      </p>
+                      <div className={styles["quiz-take-options"]}>
+                        {q.answers.map((a) => {
+                          const wasSelected = selectedId === a.id;
+                          const showAsCorrect = wasSelected && a.isCorrect;
+                          const showAsWrong = wasSelected && !a.isCorrect;
+                          const showCorrectHint = !wasSelected && a.isCorrect && selectedWasWrong;
+                          return (
+                            <div
+                              key={a.id}
+                              className={`${styles["quiz-result-answer-row"]} ${
+                                showAsCorrect
+                                  ? styles["quiz-result-answer-row--correct"]
+                                  : showAsWrong
+                                    ? styles["quiz-result-answer-row--wrong"]
+                                    : ""
+                              }`}
+                            >
+                              <span>{a.answerText}</span>
+                              {wasSelected && (
+                                <span className={styles["quiz-result-your-answer"]}>
+                                  {a.isCorrect ? " ✓" : " ✗ your answer"}
+                                </span>
+                              )}
+                              {showCorrectHint && (
+                                <span className={styles["quiz-result-correct-hint"]}>
+                                  {" "}correct answer
+                                </span>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
+                  );
+                })}
+              </div>
+            )}
             <div className={styles["quiz-modal-actions"]}>
               <button type="button" className="btn-gradient" onClick={handleRetake}>
                 Retake

--- a/app/skillmaps/[id]/components/QuizTakeModal.tsx
+++ b/app/skillmaps/[id]/components/QuizTakeModal.tsx
@@ -4,23 +4,25 @@ import React, { useState, useEffect } from "react";
 import toast from "react-hot-toast";
 import { ApiService } from "@/api/apiService";
 import { QuizQuestion, QuizAttempt } from "@/types/quiz";
-import { getLatestAttempt, getQuizQuestions, submitAttempt } from "@/api/quizApi";
+import { getQuiz, getLatestAttempt, getQuizQuestions, createAttempt, submitAttempt } from "@/api/quizApi";
 import styles from "@/styles/skillmaps.module.css";
 
-type Phase = "loading" | "taking" | "result";
+type Phase = "loading" | "taking" | "result" | "locked";
 
 type Props = {
   api: ApiService;
   open: boolean;
+  skillId: number;
   quizId: number;
   onClose: () => void;
 };
 
-const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
+const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose }) => {
   const [phase, setPhase] = useState<Phase>("loading");
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [selections, setSelections] = useState<Map<number, number>>(new Map());
   const [result, setResult] = useState<QuizAttempt | null>(null);
+  const [pendingAttemptId, setPendingAttemptId] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -28,16 +30,30 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
     setPhase("loading");
     setSelections(new Map());
     setResult(null);
+    setPendingAttemptId(null);
 
     Promise.all([
+      getQuiz(api, skillId),
       getLatestAttempt(api, quizId).catch(() => null),
       getQuizQuestions(api, quizId),
     ])
-      .then(([latestResult, qs]) => {
+      .then(([quiz, latestAttempt, qs]) => {
         setQuestions(qs);
-        if (latestResult) {
-          setResult(latestResult);
-          setPhase("result");
+
+        if (!quiz.isActive) {
+          setPhase("locked");
+          return;
+        }
+
+        if (latestAttempt) {
+          if (latestAttempt.passed === null) {
+            // resume an unsubmitted attempt from a previous session
+            setPendingAttemptId(latestAttempt.id);
+            setPhase("taking");
+          } else {
+            setResult(latestAttempt);
+            setPhase("result");
+          }
         } else {
           setPhase("taking");
         }
@@ -46,7 +62,7 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
         toast.error("Failed to load quiz.");
         onClose();
       });
-  }, [open, quizId]);
+  }, [open, quizId, skillId]);
 
   if (!open) return null;
 
@@ -59,7 +75,18 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
         quizQuestionId: q.id,
         selectedAnswerId: selections.get(q.id)!,
       }));
-      const res = await submitAttempt(api, quizId, { answers });
+
+      // reuse an in-progress attempt if one exists; otherwise create a new one
+      let attemptId = pendingAttemptId;
+      if (attemptId === null) {
+        const attempt = await createAttempt(api, quizId);
+        attemptId = attempt.id;
+        // persist so a failed submitAttempt can retry without hitting 409
+        setPendingAttemptId(attemptId);
+      }
+
+      const res = await submitAttempt(api, attemptId, { answers });
+      setPendingAttemptId(null);
       setResult(res);
       setPhase("result");
     } catch {
@@ -70,11 +97,22 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
   };
 
   const handleRetake = () => {
+    if (result?.cooldownUntil) {
+      const until = new Date(result.cooldownUntil);
+      if (until > new Date()) {
+        const diffMs = until.getTime() - Date.now();
+        const hours = Math.floor(diffMs / (1000 * 60 * 60));
+        const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+        const label = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+        toast.error(`Cooldown active — available again in ${label}.`);
+        return;
+      }
+    }
     setSelections(new Map());
+    setPendingAttemptId(null);
     setResult(null);
     setPhase("taking");
   };
-
 
   return (
     <div
@@ -93,6 +131,16 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
         onKeyDown={(e) => e.stopPropagation()}
       >
         {phase === "loading" && <p className={styles["quiz-loading"]}>Loading…</p>}
+
+        {phase === "locked" && (
+          <>
+            <h2 className="form-heading">Quiz</h2>
+            <p className={styles["quiz-loading"]}>This quiz is currently inactive.</p>
+            <div className={styles["quiz-modal-actions"]}>
+              <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
+            </div>
+          </>
+        )}
 
         {phase === "taking" && (
           <>

--- a/app/skillmaps/[id]/components/QuizTakeModal.tsx
+++ b/app/skillmaps/[id]/components/QuizTakeModal.tsx
@@ -7,7 +7,7 @@ import { QuizQuestion, QuizAttempt } from "@/types/quiz";
 import { getQuiz, getLatestAttempt, getQuizQuestions, createAttempt, submitAttempt } from "@/api/quizApi";
 import styles from "@/styles/skillmaps.module.css";
 
-type Phase = "loading" | "taking" | "result" | "locked";
+type Phase = "loading" | "taking" | "result" | "locked" | "preview";
 
 type Props = {
   api: ApiService;
@@ -15,9 +15,10 @@ type Props = {
   skillId: number;
   quizId: number;
   onClose: () => void;
+  previewOnly?: boolean;
 };
 
-const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose }) => {
+const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose, previewOnly }) => {
   const [phase, setPhase] = useState<Phase>("loading");
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [selections, setSelections] = useState<Map<number, number>>(new Map());
@@ -31,6 +32,13 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose })
     setSelections(new Map());
     setResult(null);
     setPendingAttemptId(null);
+
+    if (previewOnly) {
+      getQuizQuestions(api, quizId)
+        .then((qs) => { setQuestions(qs); setPhase("preview"); })
+        .catch(() => { toast.error("Failed to load quiz."); onClose(); });
+      return;
+    }
 
     Promise.all([
       getQuiz(api, skillId),
@@ -47,7 +55,6 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose })
 
         if (latestAttempt) {
           if (latestAttempt.passed === null) {
-            // resume an unsubmitted attempt from a previous session
             setPendingAttemptId(latestAttempt.id);
             setPhase("taking");
           } else {
@@ -62,7 +69,7 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose })
         toast.error("Failed to load quiz.");
         onClose();
       });
-  }, [open, quizId, skillId]);
+  }, [open, quizId, skillId, previewOnly]);
 
   if (!open) return null;
 
@@ -136,6 +143,31 @@ const QuizTakeModal: React.FC<Props> = ({ api, open, skillId, quizId, onClose })
           <>
             <h2 className="form-heading">Quiz</h2>
             <p className={styles["quiz-loading"]}>This quiz is currently inactive.</p>
+            <div className={styles["quiz-modal-actions"]}>
+              <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
+            </div>
+          </>
+        )}
+
+        {phase === "preview" && (
+          <>
+            <h2 className="form-heading">Quiz Preview</h2>
+            <div className={styles["quiz-question-list"]}>
+              {questions.map((q, qi) => (
+                <div key={q.id} className={styles["quiz-take-question"]}>
+                  <p className={styles["quiz-take-question-text"]}>
+                    {qi + 1}. {q.quizQuestionText}
+                  </p>
+                  <div className={styles["quiz-take-options"]}>
+                    {q.answers.map((a) => (
+                      <div key={a.id} className={styles["quiz-take-option"]}>
+                        <span>{a.answerText}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
             <div className={styles["quiz-modal-actions"]}>
               <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
             </div>

--- a/app/skillmaps/[id]/components/QuizTakeModal.tsx
+++ b/app/skillmaps/[id]/components/QuizTakeModal.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import toast from "react-hot-toast";
+import { ApiService } from "@/api/apiService";
+import { QuizQuestion, AttemptResult } from "@/types/quiz";
+import { getLatestAttempt, getQuizQuestions, submitAttempt } from "@/api/quizApi";
+import styles from "@/styles/skillmaps.module.css";
+
+type Phase = "loading" | "taking" | "result";
+
+type Props = {
+  api: ApiService;
+  open: boolean;
+  quizId: number;
+  onClose: () => void;
+};
+
+const QuizTakeModal: React.FC<Props> = ({ api, open, quizId, onClose }) => {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [questions, setQuestions] = useState<QuizQuestion[]>([]);
+  const [selections, setSelections] = useState<Map<number, number>>(new Map());
+  const [result, setResult] = useState<AttemptResult | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setPhase("loading");
+    setSelections(new Map());
+    setResult(null);
+
+    Promise.all([
+      getLatestAttempt(api, quizId).catch(() => null),
+      getQuizQuestions(api, quizId),
+    ])
+      .then(([latestResult, qs]) => {
+        setQuestions(qs);
+        if (latestResult) {
+          setResult(latestResult);
+          setPhase("result");
+        } else {
+          setPhase("taking");
+        }
+      })
+      .catch(() => {
+        toast.error("Failed to load quiz.");
+        onClose();
+      });
+  }, [open, quizId]);
+
+  if (!open) return null;
+
+  const allAnswered = questions.length > 0 && questions.every((q) => selections.has(q.id));
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const answers = questions.map((q) => ({
+        quizQuestionId: q.id,
+        selectedAnswerId: selections.get(q.id)!,
+      }));
+      const res = await submitAttempt(api, quizId, { answers });
+      setResult(res);
+      setPhase("result");
+    } catch {
+      toast.error("Failed to submit quiz.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRetake = () => {
+    setSelections(new Map());
+    setResult(null);
+    setPhase("taking");
+  };
+
+  const getResultAnswer = (questionId: number) =>
+    result?.answers.find((a) => a.quizQuestionId === questionId);
+
+  return (
+    <div
+      className={styles["modal-backdrop"]}
+      role="button"
+      tabIndex={0}
+      aria-label="Close modal"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
+      <div
+        className={`${styles["modal"]} ${styles["modal--quiz"]}`}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        {phase === "loading" && <p className={styles["quiz-loading"]}>Loading…</p>}
+
+        {phase === "taking" && (
+          <>
+            <h2 className="form-heading">Quiz</h2>
+            <div className={styles["quiz-question-list"]}>
+              {questions.map((q, qi) => (
+                <div key={q.id} className={styles["quiz-take-question"]}>
+                  <p className={styles["quiz-take-question-text"]}>
+                    {qi + 1}. {q.quizQuestionText}
+                  </p>
+                  <div className={styles["quiz-take-options"]}>
+                    {q.answers.map((a) => {
+                      const selected = selections.get(q.id) === a.id;
+                      return (
+                        <label
+                          key={a.id}
+                          className={`${styles["quiz-take-option"]} ${
+                            selected ? styles["quiz-take-option--selected"] : ""
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name={`q-${q.id}`}
+                            checked={selected}
+                            onChange={() =>
+                              setSelections((prev) => new Map(prev).set(q.id, a.id))
+                            }
+                          />
+                          <span>{a.answerText}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className={styles["quiz-modal-actions"]}>
+              <button
+                type="button"
+                className="btn-gradient"
+                onClick={handleSubmit}
+                disabled={!allAnswered || submitting}
+              >
+                {submitting ? "Submitting…" : "Submit"}
+              </button>
+              <button type="button" className="btn-ghost" onClick={onClose} disabled={submitting}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === "result" && result && (
+          <>
+            <h2 className="form-heading">Your Result</h2>
+            <p className={styles["quiz-result-score"]}>
+              {result.score} / {questions.length} correct
+            </p>
+            <div className={styles["quiz-question-list"]}>
+              {questions.map((q, qi) => {
+                const resultAnswer = getResultAnswer(q.id);
+                return (
+                  <div key={q.id} className={styles["quiz-take-question"]}>
+                    <p className={styles["quiz-take-question-text"]}>
+                      {qi + 1}. {q.quizQuestionText}
+                    </p>
+                    <div className={styles["quiz-take-options"]}>
+                      {q.answers.map((a) => {
+                        const wasSelected = resultAnswer?.selectedAnswerId === a.id;
+                        // isCorrect may be present if backend exposes it post-submission
+                        const isCorrectAnswer = a.isCorrect === true;
+                        const showAsWrongSelected =
+                          wasSelected && resultAnswer && !resultAnswer.isCorrect;
+                        const showAsCorrect =
+                          (wasSelected && resultAnswer?.isCorrect) ||
+                          (isCorrectAnswer && showAsWrongSelected);
+
+                        return (
+                          <div
+                            key={a.id}
+                            className={`${styles["quiz-result-answer-row"]} ${
+                              showAsCorrect
+                                ? styles["quiz-result-answer-row--correct"]
+                                : showAsWrongSelected
+                                  ? styles["quiz-result-answer-row--wrong"]
+                                  : ""
+                            }`}
+                          >
+                            <span>{a.answerText}</span>
+                            {wasSelected && (
+                              <span className={styles["quiz-result-your-answer"]}>
+                                {resultAnswer?.isCorrect ? " ✓" : " ✗ your answer"}
+                              </span>
+                            )}
+                            {isCorrectAnswer && showAsWrongSelected && (
+                              <span className={styles["quiz-result-correct-hint"]}>
+                                {" "}correct answer
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className={styles["quiz-modal-actions"]}>
+              <button type="button" className="btn-gradient" onClick={handleRetake}>
+                Retake
+              </button>
+              <button type="button" className="btn-ghost" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QuizTakeModal;

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -3,10 +3,11 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useAutoResize } from "@/hooks/useAutoResize";
 import { X } from "lucide-react";
-import { Skill } from "@/types/skill";
+import { Skill, SkillQuizRef } from "@/types/skill";
 import { ApiService } from "@/api/apiService";
 import { updateProgress } from "@/api/skillApi";
 import { submitSkillRating } from "@/api/sessionApi";
+import { getLatestAttempt } from "@/api/quizApi";
 import UnderstandingSlider from "./UnderstandingSlider";
 import { ratingColor } from "./UnderstandingHeatmap";
 import styles from "@/styles/skillmaps.module.css";
@@ -57,6 +58,24 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const understandingRef = useRef(0);
   const prevSessionIdRef = useRef<number | null>(null);
+
+  // Quiz state
+  const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(skill.quiz ?? null);
+  const [quizEditorOpen, setQuizEditorOpen] = useState(false);
+  const [quizTakeOpen, setQuizTakeOpen] = useState(false);
+  const [hasAttempt, setHasAttempt] = useState(false);
+
+  useEffect(() => {
+    setLocalQuiz(skill.quiz ?? null);
+  }, [skill.id]);
+
+  // Determine if student has a previous attempt (for button label)
+  useEffect(() => {
+    if (isOwner || !localQuiz) return;
+    getLatestAttempt(api, localQuiz.id)
+      .then((result) => setHasAttempt(result !== null))
+      .catch(() => {});
+  }, [api, isOwner, localQuiz?.id]);
 
   useEffect(() => {
     setUnderstood(skill.isUnderstood);
@@ -221,6 +240,37 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
           placeholder="Add your personal notes here..."
         />
       </section>
+
+      {/* Quiz section */}
+      {isOwner && (
+        <section className={styles["detail-panel-section"]}>
+          <h3 className={styles["detail-panel-label"]}>Quiz</h3>
+          <button
+            className="btn-ghost"
+            onClick={() => {
+              console.log("Open quiz editor for quiz:", localQuiz?.id ?? "(new)", "skill:", skill.id);
+              setQuizEditorOpen(true);
+            }}
+          >
+            {localQuiz ? "Edit Quiz" : "Create Quiz"}
+          </button>
+        </section>
+      )}
+
+      {!isOwner && localQuiz && (
+        <section className={styles["detail-panel-section"]}>
+          <h3 className={styles["detail-panel-label"]}>Quiz</h3>
+          <button
+            className="btn-ghost"
+            onClick={() => {
+              console.log("Open quiz take for quiz:", localQuiz.id);
+              setQuizTakeOpen(true);
+            }}
+          >
+            {hasAttempt ? "Retake Quiz" : "Take Quiz"}
+          </button>
+        </section>
+      )}
 
       {isOwner && onEdit && sessionId === null && (
         <button className={`btn-ghost ${styles["detail-panel-edit-btn"]}`} onClick={onEdit}>

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -50,9 +50,6 @@ const dotColor: Record<string, string> = {
   hard:   "hsl(330, 70%, 56%)",
 };
 
-// Set to { id: 1 } to test student quiz flow without backend
-const DEV_MOCK_QUIZ: SkillQuizRef | null = { id: 1 };
-
 const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies, onClose, isOwner, onEdit, onUnderstoodChange, api, sessionId, liveRating }) => {
   const color = dotColor[skill.difficulty] ?? "hsl(258, 24%, 40%)";
   const [notes, setNotes] = useState("");
@@ -64,13 +61,13 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
   const understandingRef = useRef(0);
   const prevSessionIdRef = useRef<number | null>(null);
 
-  const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(DEV_MOCK_QUIZ ?? skill.quiz ?? null);
+  const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(skill.quiz ?? null);
   const [quizEditorOpen, setQuizEditorOpen] = useState(false);
   const [quizTakeOpen, setQuizTakeOpen] = useState(false);
   const [hasAttempt, setHasAttempt] = useState(false);
 
   useEffect(() => {
-    setLocalQuiz(DEV_MOCK_QUIZ ?? skill.quiz ?? null);
+    setLocalQuiz(skill.quiz ?? null);
   }, [skill.id]);
 
   // Determine if student has a previous attempt (for button label)
@@ -286,6 +283,7 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
         <QuizTakeModal
           api={api}
           open={quizTakeOpen}
+          skillId={skill.id}
           quizId={localQuiz.id}
           onClose={() => setQuizTakeOpen(false)}
         />

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -64,7 +64,9 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
   const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(skill.quiz ?? null);
   const [quizEditorOpen, setQuizEditorOpen] = useState(false);
   const [quizTakeOpen, setQuizTakeOpen] = useState(false);
+  const [quizPreviewOpen, setQuizPreviewOpen] = useState(false);
   const [hasAttempt, setHasAttempt] = useState(false);
+  const [lastScore, setLastScore] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -77,13 +79,16 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
     return () => { cancelled = true; };
   }, [skill.id, api]);
 
-  // Determine if student has a previous attempt (for button label)
+  // Fetch latest attempt for button label and last score; re-runs when modal closes
   useEffect(() => {
-    if (isOwner || !localQuiz) return;
+    if (!localQuiz || quizTakeOpen) return;
     getLatestAttempt(api, localQuiz.id)
-      .then((result) => setHasAttempt(result !== null))
+      .then((result) => {
+        setHasAttempt(result !== null);
+        setLastScore(result?.passed !== null && result?.score != null ? result.score : null);
+      })
       .catch(() => {});
-  }, [api, isOwner, localQuiz?.id]);
+  }, [api, localQuiz?.id, quizTakeOpen]);
 
   useEffect(() => {
     setUnderstood(skill.isUnderstood);
@@ -262,18 +267,53 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
       {isOwner && localQuiz && (
         <section className={styles["detail-panel-section"]}>
           <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
+          {lastScore !== null && (
+            <div className={styles["live-rating-row"]}>
+              <div className={styles["live-rating-bar-track"]}>
+                <div
+                  className={styles["live-rating-bar-fill"]}
+                  style={{ width: `${lastScore}%`, background: ratingColor(lastScore) }}
+                />
+              </div>
+              <span className={styles["live-rating-value"]} style={{ color: ratingColor(lastScore) }}>
+                {lastScore}%
+              </span>
+            </div>
+          )}
+          <button className="btn-ghost" onClick={() => setQuizPreviewOpen(true)}>
             Preview Quiz
+          </button>
+          <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
+            Take Quiz
           </button>
         </section>
       )}
 
-      {!isOwner && localQuiz && (
+      {!isOwner && (
         <section className={styles["detail-panel-section"]}>
           <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
-            {hasAttempt ? "Retake Quiz" : "Take Quiz"}
-          </button>
+          {localQuiz ? (
+            <>
+              {lastScore !== null && (
+                <div className={styles["live-rating-row"]}>
+                  <div className={styles["live-rating-bar-track"]}>
+                    <div
+                      className={styles["live-rating-bar-fill"]}
+                      style={{ width: `${lastScore}%`, background: ratingColor(lastScore) }}
+                    />
+                  </div>
+                  <span className={styles["live-rating-value"]} style={{ color: ratingColor(lastScore) }}>
+                    {lastScore}%
+                  </span>
+                </div>
+              )}
+              <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
+                {hasAttempt ? "Retake Quiz" : "Take Quiz"}
+              </button>
+            </>
+          ) : (
+            <p className={styles["detail-panel-placeholder"]}>No quiz created yet.</p>
+          )}
         </section>
       )}
 
@@ -309,6 +349,17 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
           skillId={skill.id}
           quizId={localQuiz.id}
           onClose={() => setQuizTakeOpen(false)}
+        />
+      )}
+
+      {localQuiz && (
+        <QuizTakeModal
+          api={api}
+          open={quizPreviewOpen}
+          skillId={skill.id}
+          quizId={localQuiz.id}
+          onClose={() => setQuizPreviewOpen(false)}
+          previewOnly
         />
       )}
     </div>

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -249,6 +249,11 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
           <button className="btn-ghost" onClick={() => setQuizEditorOpen(true)}>
             {localQuiz ? "Edit Quiz" : "Create Quiz"}
           </button>
+          {localQuiz && (
+            <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
+              Preview Quiz
+            </button>
+          )}
         </section>
       )}
 

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -9,6 +9,7 @@ import { updateProgress } from "@/api/skillApi";
 import { submitSkillRating } from "@/api/sessionApi";
 import { getLatestAttempt } from "@/api/quizApi";
 import QuizEditorModal from "./QuizEditorModal";
+import QuizTakeModal from "./QuizTakeModal";
 import UnderstandingSlider from "./UnderstandingSlider";
 import { ratingColor } from "./UnderstandingHeatmap";
 import styles from "@/styles/skillmaps.module.css";
@@ -279,6 +280,15 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
           setQuizEditorOpen(false);
         }}
       />
+
+      {localQuiz && (
+        <QuizTakeModal
+          api={api}
+          open={quizTakeOpen}
+          quizId={localQuiz.id}
+          onClose={() => setQuizTakeOpen(false)}
+        />
+      )}
     </div>
   );
 };

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -50,6 +50,9 @@ const dotColor: Record<string, string> = {
   hard:   "hsl(330, 70%, 56%)",
 };
 
+// Set to { id: 1 } to test student quiz flow without backend
+const DEV_MOCK_QUIZ: SkillQuizRef | null = { id: 1 };
+
 const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies, onClose, isOwner, onEdit, onUnderstoodChange, api, sessionId, liveRating }) => {
   const color = dotColor[skill.difficulty] ?? "hsl(258, 24%, 40%)";
   const [notes, setNotes] = useState("");
@@ -61,14 +64,13 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
   const understandingRef = useRef(0);
   const prevSessionIdRef = useRef<number | null>(null);
 
-  // Quiz state
-  const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(skill.quiz ?? null);
+  const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(DEV_MOCK_QUIZ ?? skill.quiz ?? null);
   const [quizEditorOpen, setQuizEditorOpen] = useState(false);
   const [quizTakeOpen, setQuizTakeOpen] = useState(false);
   const [hasAttempt, setHasAttempt] = useState(false);
 
   useEffect(() => {
-    setLocalQuiz(skill.quiz ?? null);
+    setLocalQuiz(DEV_MOCK_QUIZ ?? skill.quiz ?? null);
   }, [skill.id]);
 
   // Determine if student has a previous attempt (for button label)

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -7,7 +7,7 @@ import { Skill, SkillQuizRef } from "@/types/skill";
 import { ApiService } from "@/api/apiService";
 import { updateProgress } from "@/api/skillApi";
 import { submitSkillRating } from "@/api/sessionApi";
-import { getLatestAttempt } from "@/api/quizApi";
+import { getQuiz, getLatestAttempt } from "@/api/quizApi";
 import QuizEditorModal from "./QuizEditorModal";
 import QuizTakeModal from "./QuizTakeModal";
 import UnderstandingSlider from "./UnderstandingSlider";
@@ -67,8 +67,15 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
   const [hasAttempt, setHasAttempt] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     setLocalQuiz(skill.quiz ?? null);
-  }, [skill.id]);
+    if (!skill.quiz) {
+      getQuiz(api, skill.id)
+        .then((q) => { if (!cancelled) setLocalQuiz({ id: q.id }); })
+        .catch(() => {});
+    }
+    return () => { cancelled = true; };
+  }, [skill.id, api]);
 
   // Determine if student has a previous attempt (for button label)
   useEffect(() => {
@@ -243,17 +250,21 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
       </section>
 
       {/* Quiz section */}
-      {isOwner && (
+      {isOwner && !localQuiz && (
         <section className={styles["detail-panel-section"]}>
           <h3 className={styles["detail-panel-label"]}>Quiz</h3>
           <button className="btn-ghost" onClick={() => setQuizEditorOpen(true)}>
-            {localQuiz ? "Edit Quiz" : "Create Quiz"}
+            Create Quiz
           </button>
-          {localQuiz && (
-            <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
-              Preview Quiz
-            </button>
-          )}
+        </section>
+      )}
+
+      {isOwner && localQuiz && (
+        <section className={styles["detail-panel-section"]}>
+          <h3 className={styles["detail-panel-label"]}>Quiz</h3>
+          <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
+            Preview Quiz
+          </button>
         </section>
       )}
 
@@ -266,11 +277,18 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
         </section>
       )}
 
-      {isOwner && onEdit && sessionId === null && (
-        <button className={`btn-ghost ${styles["detail-panel-edit-btn"]}`} onClick={onEdit}>
-          Edit Skill
-        </button>
-      )}
+      <div className={styles["detail-panel-bottom-actions"]}>
+        {isOwner && localQuiz && (
+          <button className="btn-ghost" onClick={() => setQuizEditorOpen(true)}>
+            Edit Quiz
+          </button>
+        )}
+        {isOwner && onEdit && sessionId === null && (
+          <button className="btn-ghost" onClick={onEdit}>
+            Edit Skill
+          </button>
+        )}
+      </div>
 
       <QuizEditorModal
         api={api}

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -8,6 +8,7 @@ import { ApiService } from "@/api/apiService";
 import { updateProgress } from "@/api/skillApi";
 import { submitSkillRating } from "@/api/sessionApi";
 import { getLatestAttempt } from "@/api/quizApi";
+import QuizEditorModal from "./QuizEditorModal";
 import UnderstandingSlider from "./UnderstandingSlider";
 import { ratingColor } from "./UnderstandingHeatmap";
 import styles from "@/styles/skillmaps.module.css";
@@ -245,13 +246,7 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
       {isOwner && (
         <section className={styles["detail-panel-section"]}>
           <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          <button
-            className="btn-ghost"
-            onClick={() => {
-              console.log("Open quiz editor for quiz:", localQuiz?.id ?? "(new)", "skill:", skill.id);
-              setQuizEditorOpen(true);
-            }}
-          >
+          <button className="btn-ghost" onClick={() => setQuizEditorOpen(true)}>
             {localQuiz ? "Edit Quiz" : "Create Quiz"}
           </button>
         </section>
@@ -260,13 +255,7 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
       {!isOwner && localQuiz && (
         <section className={styles["detail-panel-section"]}>
           <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          <button
-            className="btn-ghost"
-            onClick={() => {
-              console.log("Open quiz take for quiz:", localQuiz.id);
-              setQuizTakeOpen(true);
-            }}
-          >
+          <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
             {hasAttempt ? "Retake Quiz" : "Take Quiz"}
           </button>
         </section>
@@ -277,6 +266,19 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
           Edit Skill
         </button>
       )}
+
+      <QuizEditorModal
+        api={api}
+        open={quizEditorOpen}
+        skillMapId={skill.skillMapId}
+        skillId={skill.id}
+        quizId={localQuiz?.id ?? null}
+        onClose={() => setQuizEditorOpen(false)}
+        onSaved={(quiz) => {
+          setLocalQuiz(quiz);
+          setQuizEditorOpen(false);
+        }}
+      />
     </div>
   );
 };

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -166,17 +166,7 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
       {isOwner && liveRating != null && (
         <section className={styles["detail-panel-section"]}>
           <h3 className={styles["detail-panel-label"]}>Class Understanding</h3>
-          <div className={styles["live-rating-row"]}>
-            <div className={styles["live-rating-bar-track"]}>
-              <div
-                className={styles["live-rating-bar-fill"]}
-                style={{ width: `${liveRating}%`, background: ratingColor(liveRating) }}
-              />
-            </div>
-            <span className={styles["live-rating-value"]} style={{ color: ratingColor(liveRating) }}>
-              {liveRating}%
-            </span>
-          </div>
+          <ScoreBar score={liveRating} />
         </section>
       )}
 
@@ -254,68 +244,24 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
         />
       </section>
 
-      {/* Quiz section */}
-      {isOwner && !localQuiz && (
-        <section className={styles["detail-panel-section"]}>
-          <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          <button className="btn-ghost" onClick={() => setQuizEditorOpen(true)}>
-            Create Quiz
-          </button>
-        </section>
-      )}
-
-      {isOwner && localQuiz && (
-        <section className={styles["detail-panel-section"]}>
-          <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          {lastScore !== null && (
-            <div className={styles["live-rating-row"]}>
-              <div className={styles["live-rating-bar-track"]}>
-                <div
-                  className={styles["live-rating-bar-fill"]}
-                  style={{ width: `${lastScore}%`, background: ratingColor(lastScore) }}
-                />
-              </div>
-              <span className={styles["live-rating-value"]} style={{ color: ratingColor(lastScore) }}>
-                {lastScore}%
-              </span>
-            </div>
-          )}
-          <button className="btn-ghost" onClick={() => setQuizPreviewOpen(true)}>
-            Preview Quiz
-          </button>
-          <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
-            Take Quiz
-          </button>
-        </section>
-      )}
-
-      {!isOwner && (
-        <section className={styles["detail-panel-section"]}>
-          <h3 className={styles["detail-panel-label"]}>Quiz</h3>
-          {localQuiz ? (
-            <>
-              {lastScore !== null && (
-                <div className={styles["live-rating-row"]}>
-                  <div className={styles["live-rating-bar-track"]}>
-                    <div
-                      className={styles["live-rating-bar-fill"]}
-                      style={{ width: `${lastScore}%`, background: ratingColor(lastScore) }}
-                    />
-                  </div>
-                  <span className={styles["live-rating-value"]} style={{ color: ratingColor(lastScore) }}>
-                    {lastScore}%
-                  </span>
-                </div>
-              )}
-              <button className="btn-ghost" onClick={() => setQuizTakeOpen(true)}>
-                {hasAttempt ? "Retake Quiz" : "Take Quiz"}
-              </button>
-            </>
-          ) : (
-            <p className={styles["detail-panel-placeholder"]}>No quiz created yet.</p>
-          )}
-        </section>
-      )}
+      <section className={styles["detail-panel-section"]}>
+        <h3 className={styles["detail-panel-label"]}>Quiz</h3>
+        {isOwner
+          ? <OwnerQuizContent
+              localQuiz={localQuiz}
+              lastScore={lastScore}
+              onOpenEditor={() => setQuizEditorOpen(true)}
+              onPreview={() => setQuizPreviewOpen(true)}
+              onTake={() => setQuizTakeOpen(true)}
+            />
+          : <StudentQuizContent
+              localQuiz={localQuiz}
+              lastScore={lastScore}
+              hasAttempt={hasAttempt}
+              onTake={() => setQuizTakeOpen(true)}
+            />
+        }
+      </section>
 
       <div className={styles["detail-panel-bottom-actions"]}>
         {isOwner && localQuiz && (
@@ -367,3 +313,65 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
 };
 
 export default SkillDetailPanel;
+
+function ScoreBar({ score }: { score: number }) {
+  return (
+    <div className={styles["live-rating-row"]}>
+      <div className={styles["live-rating-bar-track"]}>
+        <div
+          className={styles["live-rating-bar-fill"]}
+          style={{ width: `${score}%`, background: ratingColor(score) }}
+        />
+      </div>
+      <span className={styles["live-rating-value"]} style={{ color: ratingColor(score) }}>
+        {score}%
+      </span>
+    </div>
+  );
+}
+
+type OwnerQuizContentProps = {
+  localQuiz: SkillQuizRef | null;
+  lastScore: number | null;
+  onOpenEditor: () => void;
+  onPreview: () => void;
+  onTake: () => void;
+};
+
+function OwnerQuizContent({ localQuiz, lastScore, onOpenEditor, onPreview, onTake }: OwnerQuizContentProps) {
+  if (!localQuiz) {
+    return (
+      <button className="btn-ghost" onClick={onOpenEditor}>
+        Create Quiz
+      </button>
+    );
+  }
+  return (
+    <>
+      {lastScore !== null && <ScoreBar score={lastScore} />}
+      <button className="btn-ghost" onClick={onPreview}>Preview Quiz</button>
+      <button className="btn-ghost" onClick={onTake}>Take Quiz</button>
+    </>
+  );
+}
+
+type StudentQuizContentProps = {
+  localQuiz: SkillQuizRef | null;
+  lastScore: number | null;
+  hasAttempt: boolean;
+  onTake: () => void;
+};
+
+function StudentQuizContent({ localQuiz, lastScore, hasAttempt, onTake }: StudentQuizContentProps) {
+  if (!localQuiz) {
+    return <p className={styles["detail-panel-placeholder"]}>No quiz created yet.</p>;
+  }
+  return (
+    <>
+      {lastScore !== null && <ScoreBar score={lastScore} />}
+      <button className="btn-ghost" onClick={onTake}>
+        {hasAttempt ? "Retake Quiz" : "Take Quiz"}
+      </button>
+    </>
+  );
+}

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -273,7 +273,6 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
       <QuizEditorModal
         api={api}
         open={quizEditorOpen}
-        skillMapId={skill.skillMapId}
         skillId={skill.id}
         quizId={localQuiz?.id ?? null}
         onClose={() => setQuizEditorOpen(false)}

--- a/app/skillmaps/[id]/components/quizUtils.ts
+++ b/app/skillmaps/[id]/components/quizUtils.ts
@@ -1,0 +1,82 @@
+import { generateUUID } from "@/utils/uuid";
+
+// contains everything needed for the quiz that doesn't need React component context
+
+export type LocalAnswer = {
+  key: string;
+  id?: number;
+  answerText: string;
+  isCorrect: boolean;
+};
+
+export type LocalQuestion = {
+  key: string;
+  id?: number;
+  quizQuestionText: string;
+  answers: LocalAnswer[];
+};
+
+export function emptyAnswer(): LocalAnswer {
+  return { key: generateUUID(), answerText: "", isCorrect: false };
+}
+
+export function emptyQuestion(): LocalQuestion {
+  return { key: generateUUID(), quizQuestionText: "", answers: [emptyAnswer()] };
+}
+
+export function validate(questions: LocalQuestion[]): string | null {
+  if (questions.length === 0) return "Add at least one question.";
+  for (const q of questions) {
+    if (!q.quizQuestionText.trim()) return "All questions must have text.";
+    if (q.answers.length === 0) return "Each question must have at least one answer.";
+    for (const a of q.answers) {
+      if (!a.answerText.trim()) return "All answers must have text.";
+    }
+    if (!q.answers.some((a) => a.isCorrect))
+      return "Each question must have one correct answer marked.";
+  }
+  return null;
+}
+
+export function updateQuestionText(qs: LocalQuestion[], key: string, text: string): LocalQuestion[] {
+  return qs.map((q) => (q.key === key ? { ...q, quizQuestionText: text } : q));
+}
+
+export function removeQuestion(qs: LocalQuestion[], key: string): LocalQuestion[] {
+  return qs.filter((q) => q.key !== key);
+}
+
+export function addQuestion(qs: LocalQuestion[]): LocalQuestion[] {
+  return [...qs, emptyQuestion()];
+}
+
+export function updateAnswerText(
+  qs: LocalQuestion[],
+  qKey: string,
+  aKey: string,
+  text: string,
+): LocalQuestion[] {
+  return qs.map((q) =>
+    q.key !== qKey
+      ? q
+      : { ...q, answers: q.answers.map((a) => (a.key === aKey ? { ...a, answerText: text } : a)) },
+  );
+}
+
+export function setCorrectAnswer(qs: LocalQuestion[], qKey: string, aKey: string): LocalQuestion[] {
+  return qs.map((q) =>
+    q.key !== qKey
+      ? q
+      : { ...q, answers: q.answers.map((a) => ({ ...a, isCorrect: a.key === aKey })) },
+  );
+}
+
+export function removeAnswer(qs: LocalQuestion[], qKey: string, aKey: string): LocalQuestion[] {
+  return qs.map((q) =>
+    q.key !== qKey ? q : { ...q, answers: q.answers.filter((a) => a.key !== aKey) },
+  );
+}
+
+export function addAnswer(qs: LocalQuestion[], qKey: string): LocalQuestion[] {
+  return qs.map((q) => (q.key === qKey ? { ...q, answers: [...q.answers, emptyAnswer()] } : q));
+}

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -696,6 +696,131 @@
   justify-content: center;
 }
 
+/* Quiz editor modal */
+
+.modal--quiz {
+  width: 580px;
+}
+
+.quiz-loading {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 24px 0;
+  margin: 0;
+}
+
+.quiz-question-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.quiz-question-block {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--ctp-surface0);
+}
+
+.quiz-answer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quiz-answer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.quiz-answer-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.quiz-correct-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.quiz-correct-label input[type="radio"] {
+  accent-color: var(--color-emerald);
+  cursor: pointer;
+}
+
+.quiz-correct-label--active {
+  color: var(--color-emerald);
+}
+
+.quiz-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-family: inherit;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.quiz-icon-btn:hover:not(:disabled) {
+  color: hsl(351, 80%, 65%);
+  background: hsla(351, 80%, 60%, 0.08);
+}
+
+.quiz-icon-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.quiz-question-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 2px;
+}
+
+.quiz-add-answer-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 0;
+  transition: color 0.15s;
+}
+
+.quiz-add-answer-btn:hover {
+  color: var(--primary-light);
+}
+
+.quiz-modal-add-question {
+  margin-top: 4px;
+  margin-bottom: 20px;
+}
+
+.quiz-modal-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
 /* Toast confirmation dialog */
 .toast-body {
   display: flex;

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -716,6 +716,28 @@
   margin-bottom: 12px;
 }
 
+.quiz-settings-row {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 4px;
+}
+
+.quiz-settings-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--ctp-subtext1);
+}
+
+.quiz-settings-input {
+  width: 70px !important;
+  text-align: center;
+}
+
 .quiz-question-block {
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -872,8 +872,11 @@
 }
 
 /* Edit skill button at bottom of detail panel */
-.detail-panel-edit-btn {
+.detail-panel-bottom-actions {
   margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 /* Live rating display (owner only) */

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -1037,6 +1037,104 @@
   color: var(--text-primary);
 }
 
+/* Quiz take modal */
+
+.quiz-take-question {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quiz-take-question-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.quiz-take-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quiz-take-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-secondary);
+  transition: border-color 0.15s, background 0.15s;
+  user-select: none;
+}
+
+.quiz-take-option:hover {
+  border-color: var(--primary);
+  background: rgba(244, 114, 182, 0.06);
+}
+
+.quiz-take-option input[type="radio"] {
+  accent-color: var(--primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.quiz-take-option--selected {
+  border-color: var(--primary);
+  background: rgba(244, 114, 182, 0.08);
+  color: var(--text-bright);
+}
+
+/* Quiz result */
+
+.quiz-result-score {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-bright);
+  margin: 0 0 20px;
+}
+
+.quiz-result-answer-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.quiz-result-answer-row--correct {
+  border-color: var(--color-emerald);
+  background: rgba(52, 211, 153, 0.08);
+  color: var(--color-emerald);
+}
+
+.quiz-result-answer-row--wrong {
+  border-color: var(--color-rose);
+  background: rgba(244, 63, 94, 0.08);
+  color: var(--color-rose);
+}
+
+.quiz-result-your-answer {
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.quiz-result-correct-hint {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-emerald);
+  opacity: 0.85;
+}
+
 /* Lane separators SVG overlay */
 .lane-svg {
   position: absolute;

--- a/app/types/quiz.ts
+++ b/app/types/quiz.ts
@@ -1,0 +1,38 @@
+export interface Quiz {
+  id: number;
+  skillId: number;
+}
+
+export interface QuizAnswer {
+  id: number;
+  quizQuestionId: number;
+  answerText: string;
+  isCorrect?: boolean; // only present for lecturer; hidden pre-submission for students
+}
+
+export interface QuizQuestion {
+  id: number;
+  quizId: number;
+  quizQuestionText: string;
+  orderIndex: number;
+  answers: QuizAnswer[];
+}
+
+export interface AttemptAnswer {
+  quizQuestionId: number;
+  selectedAnswerId: number;
+  isCorrect: boolean;
+}
+
+export interface AttemptResult {
+  id: number;
+  score: number;
+  answers: AttemptAnswer[];
+}
+
+export interface DashboardQuizSummary {
+  quizId: number;
+  skillId: number;
+  totalAttempts: number;
+  averageScore: number;
+}

--- a/app/types/quiz.ts
+++ b/app/types/quiz.ts
@@ -1,15 +1,21 @@
 export interface Quiz {
   id: number;
   skillId: number;
+  isActive: boolean;
+  cooldownHours: number;
+  passMark: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface QuizAnswer {
   id: number;
   quizQuestionId: number;
   answerText: string;
-  isCorrect?: boolean; // only present for lecturer; hidden pre-submission for students
+  isCorrect: boolean;
 }
 
+// answers are fetched separately from /quizQuestions/{id}/answers and merged client-side
 export interface QuizQuestion {
   id: number;
   quizId: number;
@@ -18,16 +24,15 @@ export interface QuizQuestion {
   answers: QuizAnswer[];
 }
 
-export interface AttemptAnswer {
-  quizQuestionId: number;
-  selectedAnswerId: number;
-  isCorrect: boolean;
-}
-
-export interface AttemptResult {
+export interface QuizAttempt {
   id: number;
-  score: number;
-  answers: AttemptAnswer[];
+  userId: number;
+  quizId: number;
+  score: number | null;
+  passed: boolean | null;
+  attemptedAt: string;
+  cooldownUntil: string | null;
+  updatedAt: string;
 }
 
 export interface DashboardQuizSummary {

--- a/app/types/skill.ts
+++ b/app/types/skill.ts
@@ -1,3 +1,7 @@
+export interface SkillQuizRef {
+  id: number;
+}
+
 export interface Skill {
   id: number;
   name: string;
@@ -11,6 +15,7 @@ export interface Skill {
   skillMapId: number;
   createdAt: string;
   updatedAt: string;
+  quiz?: SkillQuizRef | null;
 }
 
 export interface Dependency {


### PR DESCRIPTION
- Adds a full quiz flow for skill maps: owners can create, edit, preview, and delete quizzes with configurable pass mark and active/inactive toggle; students can take quizzes, see per-question result breakdowns, and retake after cooldown expires.
- Wires the entire flow to the backend: two-step attempt submission, in-progress attempt resumption, inactive quiz gate, and cooldown.
- Last attempt score is shown as a colour-coded bar in the skill detail panel for both owners and students.