### PR TITLE
bug fixes, quiz UI rework, minor logic improvement

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -34,6 +34,8 @@ export class ApiService {
         const errorInfo = await res.json();
         if (errorInfo?.message) {
           errorDetail = errorInfo.message;
+        } else if (errorInfo?.detail) {
+          errorDetail = errorInfo.detail;
         } else {
           errorDetail = JSON.stringify(errorInfo);
         }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -66,7 +66,7 @@ const Login: React.FC = () => {
 
         {/* heading */}
         <div className={styles['auth-heading']}>
-          <h2>Welcome back</h2>
+          <h2>Hello</h2>
           <p>Sign in to continue your learning journey</p>
         </div>
 

--- a/app/skillmaps/[id]/components/AskQuestionPanel.tsx
+++ b/app/skillmaps/[id]/components/AskQuestionPanel.tsx
@@ -66,14 +66,17 @@ const AskQuestionPanel: React.FC<AskQuestionPanelProps> = ({ session, skills, qu
   const active = questions.filter((q) => !q.isAddressed);
 
   const grouped = active.reduce<Record<number, Question[]>>((acc, q) => {
-    if (!acc[q.skillId]) acc[q.skillId] = [];
-    acc[q.skillId].push(q);
+    const key = q.skillId ?? -1;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(q);
     return acc;
   }, {});
 
   const sortedSkillIds = Object.keys(grouped)
     .map(Number)
     .sort((a, b) => {
+      if (a === -1) return 1;
+      if (b === -1) return -1;
       const levelA = skills.find((s) => s.id === a)?.level ?? 0;
       const levelB = skills.find((s) => s.id === b)?.level ?? 0;
       return levelA - levelB;
@@ -117,7 +120,7 @@ const AskQuestionPanel: React.FC<AskQuestionPanelProps> = ({ session, skills, qu
         <div className={styles["qa-list"]}>
           {sortedSkillIds.map((sid) => {
             const group = grouped[sid].slice().sort((a, b) => b.upvoteCount - a.upvoteCount);
-            const skillName = skillNameMap[sid] ?? `Skill #${sid}`;
+            const skillName = sid === -1 ? "General" : (skillNameMap[sid] ?? `Skill #${sid}`);
             return (
               <div key={sid} className={styles["qa-skill-group"]}>
                 <div className={styles["qa-skill-name"]}>{skillName}</div>

--- a/app/skillmaps/[id]/components/AskQuestionPanel.tsx
+++ b/app/skillmaps/[id]/components/AskQuestionPanel.tsx
@@ -62,9 +62,23 @@ const AskQuestionPanel: React.FC<AskQuestionPanelProps> = ({ session, skills, qu
     }
   };
 
-  const active = questions
-    .filter((q) => !q.isAddressed)
-    .sort((a, b) => b.upvoteCount - a.upvoteCount);
+  const skillNameMap = Object.fromEntries(skills.map((s) => [s.id, s.name]));
+
+  const active = questions.filter((q) => !q.isAddressed);
+
+  const grouped = active.reduce<Record<number, Question[]>>((acc, q) => {
+    if (!acc[q.skillId]) acc[q.skillId] = [];
+    acc[q.skillId].push(q);
+    return acc;
+  }, {});
+
+  const sortedSkillIds = Object.keys(grouped)
+    .map(Number)
+    .sort((a, b) => {
+      const levelA = skills.find((s) => s.id === a)?.level ?? 0;
+      const levelB = skills.find((s) => s.id === b)?.level ?? 0;
+      return levelA - levelB;
+    });
 
   return (
     <div className={styles["qa-ask"]}>
@@ -97,19 +111,28 @@ const AskQuestionPanel: React.FC<AskQuestionPanelProps> = ({ session, skills, qu
           Submit
         </button>
       </div>
-      {active.length > 0 && (
+      {sortedSkillIds.length > 0 && (
         <div className={styles["qa-list"]}>
-          {active.map((q) => (
-            <div key={q.id} className={styles["qa-item"]}>
-              <button
-                className={`${styles["qa-upvote-btn"]} ${upvoted.has(q.id) ? styles["qa-upvote-btn--active"] : ""}`}
-                onClick={() => handleUpvote(q.id)}
-              >
-                ▲ {q.upvoteCount}
-              </button>
-              <span className={styles["qa-text"]}>{q.text}</span>
-            </div>
-          ))}
+          {sortedSkillIds.map((sid) => {
+            const group = grouped[sid].slice().sort((a, b) => b.upvoteCount - a.upvoteCount);
+            const skillName = skillNameMap[sid] ?? `Skill #${sid}`;
+            return (
+              <div key={sid} className={styles["qa-skill-group"]}>
+                <div className={styles["qa-skill-name"]}>{skillName}</div>
+                {group.map((q) => (
+                  <div key={q.id} className={styles["qa-item"]}>
+                    <button
+                      className={`${styles["qa-upvote-btn"]} ${upvoted.has(q.id) ? styles["qa-upvote-btn--active"] : ""}`}
+                      onClick={() => handleUpvote(q.id)}
+                    >
+                      ▲ {q.upvoteCount}
+                    </button>
+                    <span className={styles["qa-text"]}>{q.text}</span>
+                  </div>
+                ))}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/app/skillmaps/[id]/components/QuizTakeModal.tsx
+++ b/app/skillmaps/[id]/components/QuizTakeModal.tsx
@@ -5,9 +5,10 @@ import toast from "react-hot-toast";
 import { ApiService } from "@/api/apiService";
 import { QuizQuestion, QuizAttempt } from "@/types/quiz";
 import { getQuiz, getLatestAttempt, getQuizQuestions, createAttempt, submitAttempt } from "@/api/quizApi";
+import { formatCooldownLabel } from "./quizUtils";
 import styles from "@/styles/skillmaps.module.css";
 
-type Phase = "loading" | "taking" | "result" | "locked" | "preview";
+type Phase = "loading" | "taking" | "result" | "locked" | "preview" | "retakeConfirm";
 
 type QuizTakeModalProps = {
   api: ApiService;
@@ -16,12 +17,13 @@ type QuizTakeModalProps = {
   quizId: number;
   onClose: () => void;
   previewOnly?: boolean;
+  mode?: "normal" | "viewResult" | "retake";
   sessionStartedAt?: string;
   savedSelections?: Map<number, number>;
   onSubmitSuccess?: (selections: Map<number, number>, result: QuizAttempt) => void;
 };
 
-const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizId, onClose, previewOnly, sessionStartedAt, savedSelections, onSubmitSuccess }) => {
+const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizId, onClose, previewOnly, mode = "normal", sessionStartedAt, savedSelections, onSubmitSuccess }) => {
   const [phase, setPhase] = useState<Phase>("loading");
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [selections, setSelections] = useState<Map<number, number>>(new Map());
@@ -41,6 +43,41 @@ const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizI
     if (previewOnly) {
       getQuizQuestions(api, quizId)
         .then((qs) => { setQuestions(qs); setPhase("preview"); })
+        .catch(() => { toast.error("Failed to load quiz."); onClose(); });
+      return;
+    }
+
+    if (mode === "viewResult") {
+      Promise.all([
+        getLatestAttempt(api, quizId).catch(() => null),
+        getQuizQuestions(api, quizId),
+      ])
+        .then(([latestAttempt, qs]) => {
+          setQuestions(qs);
+          if (latestAttempt && latestAttempt.passed !== null) {
+            setResult(latestAttempt);
+            setPhase("result");
+          } else {
+            toast.error("No completed attempt found.");
+            onClose();
+          }
+        })
+        .catch(() => { toast.error("Failed to load quiz."); onClose(); });
+      return;
+    }
+
+    if (mode === "retake") {
+      Promise.all([
+        getQuiz(api, skillId),
+        getLatestAttempt(api, quizId).catch(() => null),
+        getQuizQuestions(api, quizId),
+      ])
+        .then(([quiz, latestAttempt, qs]) => {
+          setQuestions(qs);
+          if (!quiz.isActive) { setPhase("locked"); return; }
+          if (latestAttempt) setResult(latestAttempt);
+          setPhase("retakeConfirm");
+        })
         .catch(() => { toast.error("Failed to load quiz."); onClose(); });
       return;
     }
@@ -84,7 +121,7 @@ const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizI
         toast.error("Failed to load quiz.");
         onClose();
       });
-  }, [open, quizId, skillId, previewOnly, sessionStartedAt]);
+  }, [open, quizId, skillId, previewOnly, sessionStartedAt, mode]);
 
   if (!open) return null;
 
@@ -122,13 +159,8 @@ const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizI
 
   const handleRetake = () => {
     if (result?.cooldownUntil) {
-      const until = new Date(result.cooldownUntil);
-      if (until > new Date()) {
-        // convert remaining ms into whole hours plus the leftover minutes
-        const diffMs = until.getTime() - Date.now();
-        const hours = Math.floor(diffMs / (1000 * 60 * 60));
-        const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-        const label = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+      const label = formatCooldownLabel(result.cooldownUntil);
+      if (label) {
         toast.error(`Cooldown active — available again in ${label}.`);
         return;
       }
@@ -158,6 +190,13 @@ const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizI
         {phase === "loading" && <LoadingPhase />}
         {phase === "locked" && <LockedPhase onClose={onClose} />}
         {phase === "preview" && <PreviewPhase questions={questions} onClose={onClose} />}
+        {phase === "retakeConfirm" && (
+          <RetakeConfirmPhase
+            lastScore={result?.score ?? null}
+            onRetake={handleRetake}
+            onClose={onClose}
+          />
+        )}
         {phase === "taking" && (
           <TakingPhase
             questions={questions}
@@ -173,10 +212,10 @@ const QuizTakeModal: React.FC<QuizTakeModalProps> = ({ api, open, skillId, quizI
           <ResultPhase
             result={result}
             questions={questions}
-            selections={selections}
+            selections={mode === "viewResult" ? (savedSelections ?? new Map()) : selections}
             onRetake={handleRetake}
             onClose={onClose}
-            disableRetake={submittedInSession}
+            disableRetake={submittedInSession || mode === "viewResult"}
           />
         )}
       </div>
@@ -196,6 +235,21 @@ function LockedPhase({ onClose }: { onClose: () => void }) {
       <h2 className="form-heading">Quiz</h2>
       <p className={styles["quiz-loading"]}>This quiz is currently inactive.</p>
       <div className={styles["quiz-modal-actions"]}>
+        <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
+      </div>
+    </>
+  );
+}
+
+function RetakeConfirmPhase({ lastScore, onRetake, onClose }: { lastScore: number | null; onRetake: () => void; onClose: () => void }) {
+  return (
+    <>
+      <h2 className="form-heading">Retake Quiz</h2>
+      {lastScore !== null && (
+        <p className={styles["quiz-result-score"]}>Your last score: {lastScore}%</p>
+      )}
+      <div className={styles["quiz-modal-actions"]}>
+        <button type="button" className="btn-gradient" onClick={onRetake}>Retake</button>
         <button type="button" className="btn-ghost" onClick={onClose}>Close</button>
       </div>
     </>

--- a/app/skillmaps/[id]/components/SkillDetailPanel.tsx
+++ b/app/skillmaps/[id]/components/SkillDetailPanel.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
+import toast from "react-hot-toast";
 import { useAutoResize } from "@/hooks/useAutoResize";
 import { X } from "lucide-react";
 import { Skill, SkillQuizRef } from "@/types/skill";
+import { QuizAttempt } from "@/types/quiz";
 import { ApiService } from "@/api/apiService";
 import { updateProgress } from "@/api/skillApi";
 import { submitSkillRating } from "@/api/sessionApi";
 import { getQuiz, getLatestAttempt } from "@/api/quizApi";
+import { formatCooldownLabel } from "./quizUtils";
 import QuizEditorModal from "./QuizEditorModal";
 import QuizTakeModal from "./QuizTakeModal";
 import UnderstandingSlider from "./UnderstandingSlider";
@@ -61,11 +64,9 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
   const understandingRef = useRef(0);
 
   const [localQuiz, setLocalQuiz] = useState<SkillQuizRef | null>(skill.quiz ?? null);
-  const [quizEditorOpen, setQuizEditorOpen] = useState(false);
-  const [quizTakeOpen, setQuizTakeOpen] = useState(false);
-  const [quizPreviewOpen, setQuizPreviewOpen] = useState(false);
-  const [hasAttempt, setHasAttempt] = useState(false);
-  const [lastScore, setLastScore] = useState<number | null>(null);
+  const [quizModal, setQuizModal] = useState<"editor" | "take" | "retake" | "viewResult" | "preview" | null>(null);
+  const [lastAttempt, setLastAttempt] = useState<QuizAttempt | null>(null);
+  const [savedSelections, setSavedSelections] = useState<Map<number, number>>(new Map());
 
   useEffect(() => {
     let cancelled = false;
@@ -78,16 +79,33 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
     return () => { cancelled = true; };
   }, [skill.id, api]);
 
-  // Fetch latest attempt for button label and last score; re-runs when modal closes
+  const hasAttempt = lastAttempt !== null;
+  const lastScore = lastAttempt?.score != null && lastAttempt?.passed != null ? lastAttempt.score : null;
+
+  // Fetch latest attempt for button label and last score; re-runs when take/retake modals close
   useEffect(() => {
-    if (!localQuiz || quizTakeOpen) return;
+    const submittingModal = quizModal === "take" || quizModal === "retake";
+    if (!localQuiz || submittingModal) return;
     getLatestAttempt(api, localQuiz.id)
-      .then((result) => {
-        setHasAttempt(result !== null);
-        setLastScore(result?.passed !== null && result?.score != null ? result.score : null);
-      })
+      .then((attempt) => { setLastAttempt(attempt ?? null); })
       .catch(() => {});
-  }, [api, localQuiz?.id, quizTakeOpen]);
+  }, [api, localQuiz?.id, quizModal]);
+
+  const handleSubmitSuccess = (sels: Map<number, number>, result: QuizAttempt) => {
+    setSavedSelections(sels);
+    setLastAttempt(result);
+  };
+
+  const handleRetakeClick = () => {
+    if (lastAttempt?.cooldownUntil) {
+      const label = formatCooldownLabel(lastAttempt.cooldownUntil);
+      if (label) {
+        toast.error(`Cooldown active — available again in ${label}.`);
+        return;
+      }
+    }
+    setQuizModal("retake");
+  };
 
   useEffect(() => {
     setUnderstood(skill.isUnderstood);
@@ -240,24 +258,29 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
         {isOwner
           ? <OwnerQuizContent
               localQuiz={localQuiz}
+              hasAttempt={hasAttempt}
               lastScore={lastScore}
-              onOpenEditor={() => setQuizEditorOpen(true)}
-              onPreview={() => setQuizPreviewOpen(true)}
-              onTake={() => setQuizTakeOpen(true)}
+              onOpenEditor={() => setQuizModal("editor")}
+              onPreview={() => setQuizModal("preview")}
+              onTake={() => setQuizModal("take")}
+              onSeeLastAttempt={() => setQuizModal("viewResult")}
+              onRetake={handleRetakeClick}
             />
           : <StudentQuizContent
               localQuiz={localQuiz}
               lastScore={lastScore}
               hasAttempt={hasAttempt}
               inSession={sessionId !== null}
-              onTake={() => setQuizTakeOpen(true)}
+              onTake={() => setQuizModal("take")}
+              onSeeLastAttempt={() => setQuizModal("viewResult")}
+              onRetake={handleRetakeClick}
             />
         }
       </section>
 
       <div className={styles["detail-panel-bottom-actions"]}>
         {isOwner && localQuiz && (
-          <button className="btn-ghost" onClick={() => setQuizEditorOpen(true)}>
+          <button className="btn-ghost" onClick={() => setQuizModal("editor")}>
             Edit Quiz
           </button>
         )}
@@ -270,33 +293,58 @@ const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({ skill, dependencies
 
       <QuizEditorModal
         api={api}
-        open={quizEditorOpen}
+        open={quizModal === "editor"}
         skillId={skill.id}
         quizId={localQuiz?.id ?? null}
-        onClose={() => setQuizEditorOpen(false)}
+        onClose={() => setQuizModal(null)}
         onSaved={(quiz) => {
           setLocalQuiz(quiz);
-          setQuizEditorOpen(false);
+          setQuizModal(null);
         }}
       />
 
       {localQuiz && (
         <QuizTakeModal
           api={api}
-          open={quizTakeOpen}
+          open={quizModal === "take"}
           skillId={skill.id}
           quizId={localQuiz.id}
-          onClose={() => setQuizTakeOpen(false)}
+          onClose={() => setQuizModal(null)}
+          onSubmitSuccess={handleSubmitSuccess}
         />
       )}
 
       {localQuiz && (
         <QuizTakeModal
           api={api}
-          open={quizPreviewOpen}
+          open={quizModal === "retake"}
           skillId={skill.id}
           quizId={localQuiz.id}
-          onClose={() => setQuizPreviewOpen(false)}
+          onClose={() => setQuizModal(null)}
+          mode="retake"
+          onSubmitSuccess={handleSubmitSuccess}
+        />
+      )}
+
+      {localQuiz && (
+        <QuizTakeModal
+          api={api}
+          open={quizModal === "viewResult"}
+          skillId={skill.id}
+          quizId={localQuiz.id}
+          onClose={() => setQuizModal(null)}
+          mode="viewResult"
+          savedSelections={savedSelections}
+        />
+      )}
+
+      {localQuiz && (
+        <QuizTakeModal
+          api={api}
+          open={quizModal === "preview"}
+          skillId={skill.id}
+          quizId={localQuiz.id}
+          onClose={() => setQuizModal(null)}
           previewOnly
         />
       )}
@@ -324,13 +372,16 @@ function ScoreBar({ score }: { score: number }) {
 
 type OwnerQuizContentProps = {
   localQuiz: SkillQuizRef | null;
+  hasAttempt: boolean;
   lastScore: number | null;
   onOpenEditor: () => void;
   onPreview: () => void;
   onTake: () => void;
+  onSeeLastAttempt: () => void;
+  onRetake: () => void;
 };
 
-function OwnerQuizContent({ localQuiz, lastScore, onOpenEditor, onPreview, onTake }: OwnerQuizContentProps) {
+function OwnerQuizContent({ localQuiz, hasAttempt, lastScore, onOpenEditor, onPreview, onTake, onSeeLastAttempt, onRetake }: OwnerQuizContentProps) {
   if (!localQuiz) {
     return (
       <button className="btn-ghost" onClick={onOpenEditor}>
@@ -342,7 +393,14 @@ function OwnerQuizContent({ localQuiz, lastScore, onOpenEditor, onPreview, onTak
     <>
       {lastScore !== null && <ScoreBar score={lastScore} />}
       <button className="btn-ghost" onClick={onPreview}>Preview Quiz</button>
-      <button className="btn-ghost" onClick={onTake}>Take Quiz</button>
+      {hasAttempt ? (
+        <>
+          <button className="btn-ghost" onClick={onSeeLastAttempt}>See Last Attempt</button>
+          <button className="btn-ghost" onClick={onRetake}>Retake Quiz</button>
+        </>
+      ) : (
+        <button className="btn-ghost" onClick={onTake}>Take Quiz</button>
+      )}
     </>
   );
 }
@@ -353,9 +411,11 @@ type StudentQuizContentProps = {
   hasAttempt: boolean;
   inSession: boolean;
   onTake: () => void;
+  onSeeLastAttempt: () => void;
+  onRetake: () => void;
 };
 
-function StudentQuizContent({ localQuiz, lastScore, hasAttempt, inSession, onTake }: StudentQuizContentProps) {
+function StudentQuizContent({ localQuiz, lastScore, hasAttempt, inSession, onTake, onSeeLastAttempt, onRetake }: StudentQuizContentProps) {
   if (!localQuiz) {
     return <p className={styles["detail-panel-placeholder"]}>No quiz created yet.</p>;
   }
@@ -364,9 +424,14 @@ function StudentQuizContent({ localQuiz, lastScore, hasAttempt, inSession, onTak
       {lastScore !== null && <ScoreBar score={lastScore} />}
       {inSession
         ? <p className={styles["detail-panel-placeholder"]}>Quiz taking is handled via a lecturer&apos;s prompt during an active collaboration mode.</p>
-        : <button className="btn-ghost" onClick={onTake}>
-            {hasAttempt ? "Retake Quiz" : "Take Quiz"}
-          </button>
+        : hasAttempt
+          ? (
+            <>
+              <button className="btn-ghost" onClick={onSeeLastAttempt}>See Last Attempt</button>
+              <button className="btn-ghost" onClick={onRetake}>Retake Quiz</button>
+            </>
+          )
+          : <button className="btn-ghost" onClick={onTake}>Take Quiz</button>
       }
     </>
   );

--- a/app/skillmaps/[id]/components/quizUtils.ts
+++ b/app/skillmaps/[id]/components/quizUtils.ts
@@ -80,3 +80,14 @@ export function removeAnswer(qs: LocalQuestion[], qKey: string, aKey: string): L
 export function addAnswer(qs: LocalQuestion[], qKey: string): LocalQuestion[] {
   return qs.map((q) => (q.key === qKey ? { ...q, answers: [...q.answers, emptyAnswer()] } : q));
 }
+
+// Returns a human-readable label like "2h 15m" if cooldown is still active, null if it has expired.
+export function formatCooldownLabel(cooldownUntil: string): string | null {
+  const until = new Date(cooldownUntil);
+  if (until <= new Date()) return null;
+  // convert remaining ms into whole hours plus the leftover minutes
+  const diffMs = until.getTime() - Date.now();
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}

--- a/app/skillmaps/[id]/edit/page.tsx
+++ b/app/skillmaps/[id]/edit/page.tsx
@@ -139,33 +139,14 @@ const EditSkillMapPage: React.FC = () => {
                 role="switch"
                 aria-checked={isPublic}
                 onClick={() => setIsPublic(!isPublic)}
-                style={{
-                  position: "relative",
-                  width: 44,
-                  height: 24,
-                  borderRadius: 12,
-                  border: "none",
-                  cursor: "pointer",
-                  background: isPublic ? "linear-gradient(135deg, var(--primary, #e91e8c), var(--secondary, #9333ea))" : "rgba(255,255,255,0.15)",
-                  transition: "background 0.2s",
-                  flexShrink: 0,
-                }}
+                className="toggle-switch"
               >
-                <span style={{
-                  position: "absolute",
-                  top: 3,
-                  left: isPublic ? 23 : 3,
-                  width: 18,
-                  height: 18,
-                  borderRadius: "50%",
-                  background: "white",
-                  transition: "left 0.2s",
-                }} />
+                <span className="toggle-switch-thumb" />
               </button>
             </div>
             <button type="submit" className="btn-gradient btn-full">Save</button>
             <button type="button" className="btn-ghost btn-full" onClick={() => router.push(`/skillmaps/${id}`)}>Cancel</button>
-<div style={{ borderTop: "1px solid rgba(255,255,255,0.1)", paddingTop: "1rem", marginTop: "0.5rem" }}>
+            <div className="form-section-divider">
               {!showDeleteConfirm ? (
                 <button
                   type="button"
@@ -175,11 +156,10 @@ const EditSkillMapPage: React.FC = () => {
                   Delete Skill Map
                 </button>
               ) : (
-                <div style={{ display: "flex", gap: "0.5rem" }}>
+                <div className="form-confirm-row">
                   <button
                     type="button"
                     className="btn-ghost btn-full"
-                    style={{ justifyContent: "center" }}
                     onClick={() => setShowDeleteConfirm(false)}
                   >
                     Cancel

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -10,7 +10,8 @@ import { useDashboardPolling } from "@/hooks/useDashboardPolling";
 import { ApiContext } from "@/context/ApiContext";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import { getMe } from "@/api/userApi";
-import { getSkillMap, getSkillMapGraph, updateSkillMap, exportSkillMap } from "@/api/skillmapApi";
+import { getSkillMap, getSkillMapGraph, updateSkillMap } from "@/api/skillmapApi";
+import { downloadSkillMapExport } from "@/utils/exportUtils";
 import { createDependency, deleteDependency, getSkill, updateSkill } from "@/api/skillApi";
 import { startSession, endSession } from "@/api/sessionApi";
 import { ApplicationError } from "@/types/error";
@@ -199,20 +200,7 @@ const SkillMapEditorPage: React.FC = () => {
     router.push("/login");
   };
 
-  const handleExport = async () => {
-    try {
-      const blob = await exportSkillMap(api, id);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${skillMap?.title ?? "skillmap"}-export.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-      toast.success("Skill map exported!");
-    } catch (err) {
-      toast.error((err as ApplicationError).details ?? "Failed to export skill map.");
-    }
-  };
+  const handleExport = () => downloadSkillMapExport(api, id, skillMap?.title ?? "skillmap");
 
   const handleAddSkill = () => {
     setEditingSkill(null);

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, importSkillMap } from "@/api/skillmapApi";
+import { getActiveSession } from "@/api/sessionApi";
 import { downloadSkillMapExport } from "@/utils/exportUtils";
 import { getMe } from "@/api/userApi";
 import { SkillMap } from "@/types/skillmap";
@@ -16,6 +17,7 @@ type MapStats = {
   skillCount: number;
   unlockedCount: number;
   memberCount: number;
+  hasActiveSession: boolean;
 };
 import toast from "react-hot-toast";
 import styles from "@/styles/skillmaps.module.css";
@@ -104,14 +106,16 @@ const SkillMapsPage: React.FC = () => {
 
         const statsEntries = await Promise.all(
           maps.map(async (map) => {
-            const [graph, members] = await Promise.all([
+            const [graph, members, session] = await Promise.all([
               getSkillMapGraph(api, map.id),
               getSkillMapMembers(api, map.id),
+              getActiveSession(api, map.id).catch(() => null),
             ]);
             return [map.id, {
               skillCount: graph.skills.length,
               unlockedCount: graph.skills.filter((s) => s.isUnderstood).length,
               memberCount: members.filter((m) => m.role === "STUDENT").length,
+              hasActiveSession: session !== null,
             }] as [number, MapStats];
           })
         );
@@ -236,12 +240,15 @@ const SkillMapsPage: React.FC = () => {
 
       <div className={styles['sm-grid']}>
         {skillMaps.filter((m) => m.ownerId === user?.id).map((map) => (
-          <div key={map.id} className={`${styles['sm-card']} ${styles['sm-card--owner']}`} role="button" tabIndex={0} aria-label={`Open skill map: ${map.title}`} onClick={() => router.push(`/skillmaps/${map.id}`)} onKeyDown={(e) => e.key === "Enter" && router.push(`/skillmaps/${map.id}`)}>
+          <div key={map.id} className={`${styles['sm-card']} ${styles['sm-card--owner']} ${mapStats[map.id]?.hasActiveSession ? styles['sm-card--live'] : ''}`} role="button" tabIndex={0} aria-label={`Open skill map: ${map.title}`} onClick={() => router.push(`/skillmaps/${map.id}`)} onKeyDown={(e) => e.key === "Enter" && router.push(`/skillmaps/${map.id}`)}>
             <div className={styles['sm-card-top']}>
               <div>
                 <div className={styles['sm-card-title']}>{map.title}</div>
                 <div className={styles['sm-card-subtitle']}>{map.description}</div>
               </div>
+              {mapStats[map.id]?.hasActiveSession && (
+                <span className={styles['sm-live-badge']}>● LIVE</span>
+              )}
             </div>
 
             {map.inviteCode && (
@@ -300,12 +307,15 @@ const SkillMapsPage: React.FC = () => {
           <div className={styles['sm-section-title']}>JOINED MAPS</div>
           <div className={styles['sm-grid']}>
             {skillMaps.filter((m) => m.ownerId !== user?.id).map((map) => (
-              <div key={map.id} className={styles['sm-card']} role="button" tabIndex={0} aria-label={`Open skill map: ${map.title}`} onClick={() => router.push(`/skillmaps/${map.id}`)} onKeyDown={(e) => e.key === "Enter" && router.push(`/skillmaps/${map.id}`)}>
+              <div key={map.id} className={`${styles['sm-card']} ${mapStats[map.id]?.hasActiveSession ? styles['sm-card--live'] : ''}`} role="button" tabIndex={0} aria-label={`Open skill map: ${map.title}`} onClick={() => router.push(`/skillmaps/${map.id}`)} onKeyDown={(e) => e.key === "Enter" && router.push(`/skillmaps/${map.id}`)}>
                 <div className={styles['sm-card-top']}>
                   <div>
                     <div className={styles['sm-card-title']}>{map.title}</div>
                     <div className={styles['sm-card-subtitle']}>{map.description}</div>
                   </div>
+                  {mapStats[map.id]?.hasActiveSession && (
+                    <span className={styles['sm-live-badge']}>● LIVE</span>
+                  )}
                 </div>
 
                 <div className={styles['sm-card-meta']}>

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -3,7 +3,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
-import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, exportSkillMap, importSkillMap } from "@/api/skillmapApi";
+import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, importSkillMap } from "@/api/skillmapApi";
+import { downloadSkillMapExport } from "@/utils/exportUtils";
 import { getMe } from "@/api/userApi";
 import { SkillMap } from "@/types/skillmap";
 import { User } from "@/types/user";
@@ -48,20 +49,7 @@ const SkillMapsPage: React.FC = () => {
     }
   };
 
-  const handleExport = async (mapId: number, title: string) => {
-    try {
-      const blob = await exportSkillMap(api, mapId);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${title}-export.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-      toast.success("Skill map exported!");
-    } catch (err) {
-      toast.error((err as ApplicationError).details ?? "Failed to export skill map.");
-    }
-  };
+  const handleExport = (mapId: number, title: string) => downloadSkillMapExport(api, mapId, title);
 
   const handleLogout = async () => {
     try {

--- a/app/styles/collab.module.css
+++ b/app/styles/collab.module.css
@@ -257,7 +257,21 @@
   font-size: 13px;
   color: var(--text-primary);
   line-height: 1.4;
+}
+
+.qa-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   flex: 1;
+}
+
+.qa-skill-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 /* Q&A panel — owner view */

--- a/app/styles/forms.css
+++ b/app/styles/forms.css
@@ -146,3 +146,48 @@ textarea::placeholder {
 .toggle-password:hover {
   color: var(--text-secondary);
 }
+
+/* toggle switch (public/private) */
+.toggle-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.15);
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.toggle-switch[aria-checked="true"] {
+  background: linear-gradient(135deg, var(--primary, #e91e8c), var(--secondary, #9333ea));
+}
+
+.toggle-switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  transition: left 0.2s;
+}
+
+.toggle-switch[aria-checked="true"] .toggle-switch-thumb {
+  left: 23px;
+}
+
+/* delete section divider at bottom of edit form */
+.form-section-divider {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 1rem;
+  margin-top: 0.5rem;
+}
+
+/* confirm/cancel row inside form-section-divider */
+.form-confirm-row {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -334,6 +334,16 @@
   margin-top: 0;
 }
 
+.sm-card--live {
+  border-color: var(--color-orange);
+  box-shadow: 0 0 0 2px rgba(251, 146, 60, 0.2), 0 0 18px rgba(251, 146, 60, 0.12);
+}
+
+.sm-card--live:hover {
+  border-color: var(--color-orange);
+  box-shadow: 0 0 0 2px rgba(251, 146, 60, 0.35), 0 0 22px rgba(251, 146, 60, 0.2);
+}
+
 
 .sm-continue {
   font-size: 13px;

--- a/app/utils/domain.ts
+++ b/app/utils/domain.ts
@@ -8,5 +8,5 @@ import { isProduction } from "@/utils/environment";
 export function getApiDomain(): string {
   const prodUrl = process.env.NEXT_PUBLIC_PROD_API_URL ?? "";
   const devUrl = "http://localhost:8080";
-  return isProduction() ? prodUrl : devUrl;
+  return isProduction() ? prodUrl.replace(/\/+$/, "") : devUrl;
 }

--- a/app/utils/exportUtils.ts
+++ b/app/utils/exportUtils.ts
@@ -1,0 +1,19 @@
+import { exportSkillMap } from "@/api/skillmapApi";
+import { ApiService } from "@/api/apiService";
+import { ApplicationError } from "@/types/error";
+import toast from "react-hot-toast";
+
+export async function downloadSkillMapExport(api: ApiService, id: number, title: string): Promise<void> {
+  try {
+    const blob = await exportSkillMap(api, id);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${title}-export.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success("Skill map exported!");
+  } catch (err) {
+    toast.error((err as ApplicationError).details ?? "Failed to export skill map.");
+  }
+}


### PR DESCRIPTION
- Quiz flow redesign: Owner view gets "Preview Quiz" / "Take Quiz" before first attempt, then "Preview Quiz" / "See Last Attempt" / "Retake Quiz" after. Student view gets "Take Quiz" before first attempt, then "See Last Attempt" / "Retake Quiz". "Retake Quiz" opens a confirmation screen showing only the last score, no previous answers shown
- Live session fixes: Student question panel now groups questions by skill with a named header, matching the owner/lecturer view (#121). Skillmaps overview highlights maps with an active session via an orange border glow and live badge (#122)
- API fix: Strip trailing slash from the production API base URL to prevent double-slash redirects that silently dropped the Authorization header.
- Login: changed "Welcome back" to "Hello" to avoid confusion on first login/registration (#120)
- Code quality: Removed inline styles from the edit page into CSS classes; extracted duplicated handleExport logic into a shared exportUtils utility; consolidated modal boolean flags into a single enum state; extracted cooldown label formatting into quizUtils.ts