### PR TITLE
Bug & issue fixes #119, #124, #236, refactoring

### DIFF
--- a/app/api/skillmapApi.ts
+++ b/app/api/skillmapApi.ts
@@ -41,6 +41,10 @@ export function deleteSkillMap(api: ApiService, id: number): Promise<void> {
   return api.delete<void>(`/skillmaps/${id}`);
 }
 
+export function leaveSkillMap(api: ApiService, mapId: number, userId: number): Promise<void> {
+  return api.delete<void>(`/skillmaps/${mapId}/members/${userId}`);
+}
+
 export function exportSkillMap(api: ApiService, id: number): Promise<Blob> {
   return api.download(`/skillmaps/${id}/export`);
 }

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -10,7 +10,8 @@ import { useDashboardPolling } from "@/hooks/useDashboardPolling";
 import { ApiContext } from "@/context/ApiContext";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import { getMe } from "@/api/userApi";
-import { getSkillMap, getSkillMapGraph, updateSkillMap } from "@/api/skillmapApi";
+import { getSkillMap, getSkillMapGraph, updateSkillMap, leaveSkillMap } from "@/api/skillmapApi";
+import { confirmToast } from "@/utils/confirmToast";
 import { downloadSkillMapExport } from "@/utils/exportUtils";
 import { createDependency, deleteDependency, getSkill, updateSkill } from "@/api/skillApi";
 import { startSession, endSession } from "@/api/sessionApi";
@@ -201,6 +202,19 @@ const SkillMapEditorPage: React.FC = () => {
 
   const handleExport = () => downloadSkillMapExport(api, id, skillMap?.title ?? "skillmap");
 
+  const handleLeave = () => {
+    if (!user?.id || !skillMap) return;
+    const userId = user.id;
+    confirmToast(`Leave "${skillMap.title}"?`, async () => {
+      try {
+        await leaveSkillMap(api, id, userId);
+        router.push("/skillmaps");
+      } catch {
+        toast.error("Failed to leave map.");
+      }
+    });
+  };
+
   const handleAddSkill = () => {
     setEditingSkill(null);
     setModalOpen(true);
@@ -318,8 +332,7 @@ const SkillMapEditorPage: React.FC = () => {
   );
 
   const handleConfirmDeleteEdge = useCallback(
-    async (toastId: string, edge: Edge, dep: Dependency) => {
-      toast.dismiss(toastId);
+    async (edge: Edge, dep: Dependency) => {
       setEdges((eds) => eds.filter((e) => e.id !== edge.id));
       setDependencies((deps) => deps.filter((d) => d.id !== dep.id));
       try {
@@ -336,8 +349,7 @@ const SkillMapEditorPage: React.FC = () => {
   const handleEdgeClick = useCallback(
     (_: React.MouseEvent, edge: Edge) => {
       if (!isOwner) {
-        toast("You cannot delete dependencies in a joined map. Export the map and import it to edit it as your own.", {
-        });
+        toast("You cannot delete dependencies in a joined map. Export the map and import it to edit it as your own.");
         return;
       }
       const dep = dependencies.find(
@@ -346,26 +358,7 @@ const SkillMapEditorPage: React.FC = () => {
       if (!dep) return;
       if (dep.id < 0) { toast("Connection is still being saved…"); return; }
 
-      toast((t) => (
-        <div className={styles["toast-body"]}>
-          <span>Delete this dependency?</span>
-          <div className={styles["toast-actions"]}>
-            <button className="btn-gradient" onClick={() => handleConfirmDeleteEdge(t.id, edge, dep)}>
-              Confirm
-            </button>
-            <button className="btn-ghost" onClick={() => toast.dismiss(t.id)}>
-              Cancel
-            </button>
-          </div>
-        </div>
-      ), {
-        duration: Infinity,
-        style: {
-          background: "var(--bg-elevated)",
-          color: "var(--text-bright)",
-          border: "1px solid var(--border-color)",
-        },
-      });
+      confirmToast("Delete this dependency?", () => handleConfirmDeleteEdge(edge, dep));
     },
     [api, dependencies, handleConfirmDeleteEdge, isOwner]
   );
@@ -404,6 +397,11 @@ const SkillMapEditorPage: React.FC = () => {
             <button className={`btn-ghost ${styles["sm-nav-btn"]}`} onClick={() => setExportModalOpen(true)}>
               <Download size={14} />
               Export
+            </button>
+          )}
+          {!isOwner && (
+            <button className={`btn-ghost ${styles["sm-nav-btn"]}`} onClick={handleLeave}>
+              Leave joined map
             </button>
           )}
           {isOwner && skillMap?.inviteCode && (

--- a/app/skillmaps/[id]/page.tsx
+++ b/app/skillmaps/[id]/page.tsx
@@ -279,15 +279,28 @@ const SkillMapEditorPage: React.FC = () => {
       const sourceSkill = skills.find((s) => String(s.id) === connection.source);
       const targetSkill = skills.find((s) => String(s.id) === connection.target);
       if (!sourceSkill || !targetSkill) return false;
-      return sourceSkill.level < targetSkill.level;
+      if (sourceSkill.level >= targetSkill.level) return false;
+      const fromId = Number(connection.source);
+      const toId = Number(connection.target);
+      return !dependencies.some(
+        (d) =>
+          (d.fromSkillId === fromId && d.toSkillId === toId) ||
+          (d.fromSkillId === toId && d.toSkillId === fromId)
+      );
     },
-    [skills]
+    [skills, dependencies]
   );
 
   const handleConnect = useCallback(
     async (connection: Connection) => {
       const fromSkillId = Number(connection.source);
       const toSkillId = Number(connection.target);
+      const alreadyExists = dependencies.some(
+        (d) =>
+          (d.fromSkillId === fromSkillId && d.toSkillId === toSkillId) ||
+          (d.fromSkillId === toSkillId && d.toSkillId === fromSkillId)
+      );
+      if (alreadyExists) return;
       const newEdge: Edge = { ...connection, id: `e${fromSkillId}-${toSkillId}`, type: "gradient" };
       const provisional: Dependency = { id: -1, fromSkillId, toSkillId, createdAt: "", updatedAt: "" };
       setEdges((eds) => addEdge(newEdge, eds));
@@ -301,7 +314,7 @@ const SkillMapEditorPage: React.FC = () => {
         setDependencies((deps) => deps.filter((d) => d !== provisional));
       }
     },
-    [api, id]
+    [api, id, dependencies]
   );
 
   const handleConfirmDeleteEdge = useCallback(
@@ -322,6 +335,11 @@ const SkillMapEditorPage: React.FC = () => {
 
   const handleEdgeClick = useCallback(
     (_: React.MouseEvent, edge: Edge) => {
+      if (!isOwner) {
+        toast("You cannot delete dependencies in a joined map. Export the map and import it to edit it as your own.", {
+        });
+        return;
+      }
       const dep = dependencies.find(
         (d) => d.fromSkillId === Number(edge.source) && d.toSkillId === Number(edge.target)
       );
@@ -349,7 +367,7 @@ const SkillMapEditorPage: React.FC = () => {
         },
       });
     },
-    [api, dependencies, handleConfirmDeleteEdge]
+    [api, dependencies, handleConfirmDeleteEdge, isOwner]
   );
 
   if (loading) {

--- a/app/skillmaps/page.tsx
+++ b/app/skillmaps/page.tsx
@@ -3,7 +3,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
-import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, importSkillMap } from "@/api/skillmapApi";
+import { getSkillMaps, getSkillMapGraph, getSkillMapMembers, joinSkillMap, importSkillMap, leaveSkillMap } from "@/api/skillmapApi";
+import { confirmToast } from "@/utils/confirmToast";
 import { getActiveSession } from "@/api/sessionApi";
 import { downloadSkillMapExport } from "@/utils/exportUtils";
 import { getMe } from "@/api/userApi";
@@ -85,6 +86,19 @@ const SkillMapsPage: React.FC = () => {
         else toast.error("Failed to join map.");
       }
     }
+  };
+
+  const handleLeave = (map: SkillMap) => {
+    if (!user?.id) return;
+    const userId = user.id;
+    confirmToast(`Leave "${map.title}"?`, async () => {
+      try {
+        await leaveSkillMap(api, map.id, userId);
+        setSkillMaps((prev) => prev.filter((m) => m.id !== map.id));
+      } catch {
+        toast.error("Failed to leave map.");
+      }
+    });
   };
 
   useEffect(() => {
@@ -346,6 +360,12 @@ const SkillMapsPage: React.FC = () => {
 
                 <div className={styles['sm-card-footer']}>
                   <span className={styles['sm-continue']}>Continue Mapping &gt;</span>
+                  <button
+                    className={styles['sm-edit-btn']}
+                    onClick={(e) => { e.stopPropagation(); handleLeave(map); }}
+                  >
+                    Leave
+                  </button>
                 </div>
               </div>
             ))}

--- a/app/styles/skillmaps.module.css
+++ b/app/styles/skillmaps.module.css
@@ -864,6 +864,14 @@
 }
 
 /* Toast confirmation dialog */
+.toast-container {
+  background: var(--bg-elevated);
+  color: var(--text-bright);
+  /* rgba equivalent of --primary (#e91e8c) at low opacity for the glow ring */
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 0 0 3px rgba(233, 30, 140, 0.18), 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
 .toast-body {
   display: flex;
   flex-direction: column;

--- a/app/utils/confirmToast.tsx
+++ b/app/utils/confirmToast.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import toast from "react-hot-toast";
+import styles from "@/styles/skillmaps.module.css";
+
+export function confirmToast(message: string, onConfirm: () => Promise<void> | void): void {
+  toast(
+    (t) => {
+      const handleConfirm = async () => {
+        toast.dismiss(t.id);
+        await onConfirm();
+      };
+      return (
+        <div className={styles["toast-body"]}>
+          <span>{message}</span>
+          <div className={styles["toast-actions"]}>
+            <button className="btn-gradient btn-no-lift" onClick={handleConfirm}>
+              Confirm
+            </button>
+            <button className="btn-ghost" onClick={() => toast.dismiss(t.id)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      );
+    },
+    {
+      duration: Infinity,
+      className: styles["toast-container"],
+    }
+  );
+}


### PR DESCRIPTION
- Fix #119: Prevent circular dependency creation; isValidConnection now blocks connections between nodes that already have a dependency in either direction; handleConnect guards against the same before optimistic updates
- Fix #124: Non-owners clicking a dependency edge now see an informational toast instead of a broken delete flow
- Fix #236: Members can now leave a joined map via a "Leave joined map" button in the map editor nav and a "Leave" button on dashboard map cards
- Refactor: Extract repeated confirmation toast pattern into a shared confirmToast utility with consistent dark styling